### PR TITLE
feat: 마이페이지 기능 구현

### DIFF
--- a/src/main/java/com/grepp/matnam/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/user/UserApiController.java
@@ -1,10 +1,6 @@
 package com.grepp.matnam.app.controller.api.user;
 
-import com.grepp.matnam.app.controller.api.user.payload.JwtResponse;
-import com.grepp.matnam.app.controller.api.user.payload.PreferenceRequest;
-import com.grepp.matnam.app.controller.api.user.payload.UserSigninRequest;
-import com.grepp.matnam.app.controller.api.user.payload.UserSignupRequest;
-import com.grepp.matnam.app.controller.api.user.payload.UserResponse;
+import com.grepp.matnam.app.controller.api.user.payload.*;
 import com.grepp.matnam.app.model.user.PreferenceService;
 import com.grepp.matnam.app.model.user.UserService;
 import com.grepp.matnam.app.model.user.entity.User;
@@ -150,6 +146,27 @@ public class UserApiController {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "취향 변경 중 서버 오류가 발생했습니다.", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping
+    @Operation(summary = "회원 탈퇴", description = "사용자 계정을 비활성화(탈퇴) 처리합니다.")
+    public ResponseEntity<ApiResponse> deactivateAccount(@Validated @RequestBody UserDeactivateRequest request) {
+        try {
+            String currentUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+            userService.deactivateAccount(currentUserId, request.getPassword());
+
+            return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "회원 탈퇴 성공", null));
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(new ApiResponse(ResponseCode.BAD_REQUEST.code(), "회원 탈퇴 실패", e.getMessage()));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "회원 탈퇴 중 서버 오류가 발생했습니다.", e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/grepp/matnam/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/user/UserApiController.java
@@ -9,6 +9,8 @@ import com.grepp.matnam.infra.response.ApiResponse;
 import com.grepp.matnam.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -80,11 +82,17 @@ public class UserApiController {
 
     @PostMapping("/signin")
     @Operation(summary = "로그인", description = "사용자 로그인 후 JWT 토큰을 발급합니다.")
-    public ResponseEntity<ApiResponse> signin(@Validated @RequestBody UserSigninRequest request) {
+    public ResponseEntity<ApiResponse> signin(@Validated @RequestBody UserSigninRequest request,
+                                              HttpServletResponse response) {
         try {
             User user = userService.signin(request.getUserId(), request.getPassword());
 
             String token = jwtTokenProvider.generateToken(user.getUserId(), user.getRole().name());
+
+            Cookie jwtCookie = new Cookie("jwtToken", token);
+            jwtCookie.setMaxAge(86400);
+            jwtCookie.setPath("/");
+            response.addCookie(jwtCookie);
 
             JwtResponse jwtResponse = JwtResponse.builder()
                     .token(token)
@@ -96,12 +104,7 @@ public class UserApiController {
 
             return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "로그인 성공", jwtResponse));
 
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest()
-                    .body(new ApiResponse(ResponseCode.BAD_REQUEST.code(), "로그인 실패", e.getMessage()));
-
         } catch (Exception e) {
-            e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "로그인 중 서버 오류가 발생했습니다.", e.getMessage()));
         }
@@ -167,6 +170,46 @@ public class UserApiController {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "회원 탈퇴 중 서버 오류가 발생했습니다.", e.getMessage()));
+        }
+    }
+
+    @PutMapping("/password")
+    @Operation(summary = "비밀번호 변경", description = "사용자의 비밀번호를 변경합니다.")
+    public ResponseEntity<ApiResponse> changePassword(@Validated @RequestBody PasswordChangeRequest request) {
+        try {
+            String currentUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+            userService.changePassword(currentUserId, request.getCurrentPassword(), request.getNewPassword());
+
+            return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "비밀번호 변경 성공", null));
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(new ApiResponse(ResponseCode.BAD_REQUEST.code(), "비밀번호 변경 실패", e.getMessage()));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "비밀번호 변경 중 오류가 발생했습니다.", e.getMessage()));
+        }
+    }
+
+    @GetMapping("{userId}/temperature")
+    @Operation(summary = "사용자 매너온도 조회", description = "특정 사용자의 매너 온도를 조회합니다.")
+    public ResponseEntity<ApiResponse> getUserTemperature(@PathVariable String userId) {
+        try {
+            User user = userService.getUserById(userId);
+
+            return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "매너온도 조회 성공", user.getTemperature()));
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(new ApiResponse(ResponseCode.BAD_REQUEST.code(), "매너온도 조회 실패", e.getMessage()));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "매너온도 조회 중 오류가 발생했습니다.", e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/grepp/matnam/app/controller/api/user/payload/PasswordChangeRequest.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/user/payload/PasswordChangeRequest.java
@@ -1,0 +1,22 @@
+package com.grepp.matnam.app.controller.api.user.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordChangeRequest {
+
+    @NotBlank(message = "현재 비밀번호는 필수 입력값입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,}$", message = "비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다.")
+    private String newPassword;
+}

--- a/src/main/java/com/grepp/matnam/app/controller/api/user/payload/UserDeactivateRequest.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/user/payload/UserDeactivateRequest.java
@@ -1,0 +1,13 @@
+package com.grepp.matnam.app.controller.api.user.payload;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDeactivateRequest {
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+}

--- a/src/main/java/com/grepp/matnam/app/controller/web/user/UserController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/web/user/UserController.java
@@ -1,12 +1,31 @@
 package com.grepp.matnam.app.controller.web.user;
 
+import com.grepp.matnam.app.model.user.UserService;
+import com.grepp.matnam.app.model.user.entity.User;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 
 @Controller
+@RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/user")
 public class UserController {
+
+    private final UserService userService;
 
     @GetMapping("/signup")
     public String signupPage() {
@@ -21,5 +40,91 @@ public class UserController {
     @GetMapping("/preference")
     public String preference() {
         return "user/preference";
+    }
+
+    @GetMapping("/mypage")
+    public String mypage(Model model, HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        boolean jwtCookieFound = false;
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("jwtToken".equals(cookie.getName())) {
+                    jwtCookieFound = true;
+                    break;
+                }
+            }
+        }
+        log.info("마이페이지 접근 - JWT 쿠키 존재: " + jwtCookieFound);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String currentUser = authentication != null ? authentication.getName() : "인증 정보 없음";
+        log.info("마이페이지 접근 - 현재 인증 사용자: {}", currentUser);
+
+        if (authentication == null || "anonymousUser".equals(authentication.getName())) {
+            log.warn("인증되지 않은 사용자의 마이페이지 접근 시도");
+            return "redirect:/user/signin";
+        }
+
+        try {
+            String userId = authentication.getName();
+            log.info("인증된 사용자 ID: {}", userId);
+
+            User user = userService.getUserById(userId);
+            log.info("사용자 정보 조회 성공: {}", user.getUserId());
+
+            model.addAttribute("user", user);
+
+            // 임시 통계 데이터 (실제 구현 전까지 사용)
+            model.addAttribute("stats", new HashMap<String, Integer>() {{
+                put("hostingCount", 3);
+                put("participatingCount", 5);
+                put("restaurantCount", 2);
+            }});
+
+            // 빈 목록 추가 (실제 구현 전까지 사용)
+            model.addAttribute("allTeams", new ArrayList<>());
+            model.addAttribute("userMaps", new ArrayList<>());
+
+            return "user/mypage";
+        } catch (Exception e) {
+            log.error("마이페이지 로딩 중 오류 발생: {}", e.getMessage(), e);
+            return "redirect:/user/signin?error=profile_load_failed";
+        }
+    }
+
+    @PostMapping("/deactivate")
+    public String deactivateAccount(@RequestParam("password") String password,
+                                    HttpServletRequest request,
+                                    HttpServletResponse response) {
+        try {
+            String currentUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+            userService.deactivateAccount(currentUserId, password);
+
+            Cookie[] cookies = request.getCookies();
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+
+            SecurityContextHolder.clearContext();
+
+            return "redirect:/?message=account_deactivated";
+        } catch (Exception e) {
+            return "redirect:/user/mypage?error=" + e.getMessage();
+        }
+    }
+
+    @GetMapping("/password/change")
+    public String passwordChange() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || "anonymousUser".equals(authentication.getName())) {
+            return "redirect:/user/signin";
+        }
+
+        return "user/passwordChange";
     }
 }

--- a/src/main/java/com/grepp/matnam/app/model/user/UserService.java
+++ b/src/main/java/com/grepp/matnam/app/model/user/UserService.java
@@ -1,15 +1,13 @@
 package com.grepp.matnam.app.model.user;
 
-import com.grepp.matnam.app.model.user.entity.User;
-import com.grepp.matnam.app.model.user.code.Status;
 import com.grepp.matnam.app.model.auth.code.Role;
+import com.grepp.matnam.app.model.user.code.Status;
+import com.grepp.matnam.app.model.user.entity.User;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -51,14 +49,6 @@ public class UserService {
 
     public User signin(String userId, String password) {
         log.info("로그인 시도: " + userId);
-        log.info("UserId 타입: " + userId.getClass().getName());
-
-        Optional<User> userOptional = userRepository.findByUserId(userId);
-        if (userOptional.isPresent()) {
-            log.info("사용자 발견: " + userOptional.get().getUserId());
-        } else {
-            log.info("사용자를 찾을 수 없음: " + userId);
-        }
 
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> {
@@ -98,6 +88,37 @@ public class UserService {
 
         User updatedUser = userRepository.save(user);
         log.info("회원 탈퇴 완료: " + updatedUser.getUserId());
+
+        return updatedUser;
+    }
+
+    public User getUserById(String userId) {
+        log.info("사용자 정보 조회: " + userId);
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> {
+                    log.info("사용자 정보 조회 실패: 사용자 없음 - " + userId);
+                    return new IllegalArgumentException("사용자를 찾을 수 없습니다.");
+                });
+    }
+
+    public User changePassword(String userId, String currentPassword, String newPassword) {
+        log.info("비밀번호 변경 시도: " + userId);
+
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> {
+                    log.info("비밀번호 변경 실패: 사용자 없음 - " + userId);
+                    return new IllegalArgumentException("사용자를 찾을 수 없습니다.");
+                });
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            log.info("비밀번호 변경 실패: 현재 비밀번호 불일치 - " + userId);
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        user.setPassword(passwordEncoder.encode(newPassword));
+
+        User updatedUser = userRepository.save(user);
+        log.info("비밀번호 변경 완료: " + updatedUser.getUserId());
 
         return updatedUser;
     }

--- a/src/main/java/com/grepp/matnam/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/matnam/app/model/user/entity/User.java
@@ -60,4 +60,8 @@ public class User extends BaseEntity {
     public boolean isActivated() {
         return this.activated;
     }
+
+    public LocalDateTime createdAt() {
+        return this.createdAt;
+    }
 }

--- a/src/main/java/com/grepp/matnam/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/matnam/app/model/user/entity/User.java
@@ -56,4 +56,8 @@ public class User extends BaseEntity {
     private Status status = Status.ACTIVE;
 
     private LocalDateTime dueDate;
+
+    public boolean isActivated() {
+        return this.activated;
+    }
 }

--- a/src/main/java/com/grepp/matnam/infra/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/matnam/infra/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.grepp.matnam.infra.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -29,11 +30,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         try {
+            String requestURI = request.getRequestURI();
+            logger.info("요청 URI: " + requestURI);
+
             String jwt = parseJwt(request);
 
             if (jwt != null && tokenProvider.validateJwtToken(jwt)) {
                 String userId = tokenProvider.getUserIdFromJwtToken(jwt);
                 String role = tokenProvider.getRoleFromJwtToken(jwt);
+
+                logger.info("JWT 인증 성공: 사용자 ID = " + userId + ", 역할 = " + role);
 
                 List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
 
@@ -42,9 +48,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                logger.info("인증 객체 SecurityContext에 설정 완료");
+            } else if (jwt != null) {
+                logger.info("JWT 토큰 검증 실패");
             }
         } catch (Exception e) {
-            logger.error("JWT 인증 실패: " + e.getMessage());
+            logger.error("JWT 인증 실패: " + e.getMessage(), e);
         }
 
         filterChain.doFilter(request, response);
@@ -52,11 +61,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String parseJwt(HttpServletRequest request) {
         String headerAuth = request.getHeader("Authorization");
-
         if (StringUtils.hasText(headerAuth) && headerAuth.startsWith("Bearer ")) {
+            logger.info("Authorization 헤더에서 토큰 찾음");
             return headerAuth.substring(7);
         }
 
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("jwtToken".equals(cookie.getName())) {
+                    logger.info("쿠키에서 토큰 찾음: " + cookie.getValue().substring(0, 10) + "...");
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        logger.info("JWT 토큰을 찾을 수 없음");
         return null;
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -182,6 +182,18 @@
     </div>
 </header>
 
+<message>
+<div id="messageBox" style="display: none;
+                           background-color: #4CAF50;
+                           color: white;
+                           text-align: center;
+                           padding: 15px;
+                           margin-bottom: 20px;
+                           border-radius: 4px;">
+    회원 탈퇴가 완료되었습니다.
+</div>
+</message>
+
 <!-- 메인 배너 -->
 <section class="main-banner" style="display: flex; align-items: center; justify-content: space-between;">
     <div style="max-width: 50%;">
@@ -283,5 +295,26 @@
 <footer>
     <p>© 2023 맛남 | 이용약관 | 개인정보처리방침</p>
 </footer>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const message = urlParams.get('message');
+
+        if (message === 'account_deactivated') {
+            const messageBox = document.getElementById('messageBox');
+            messageBox.style.display = 'block';
+
+            setTimeout(function() {
+                messageBox.style.display = 'none';
+
+                const url = new URL(window.location);
+                url.searchParams.delete('message');
+                window.history.replaceState({}, document.title, url);
+            }, 5000);
+        }
+    });
+</script>
+
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -9,7 +9,7 @@
       font-family: 'Noto Sans KR', sans-serif;
       margin: 0;
       padding: 0;
-      background-color: #fff;
+      background-color: #f9f9f9;
       color: #333;
     }
     header {
@@ -18,24 +18,52 @@
       align-items: center;
       padding: 1rem 2rem;
       border-bottom: 1px solid #eee;
+      background-color: #fff;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
     }
     .header-left {
       display: flex;
       align-items: center;
       gap: 2rem;
     }
-    nav a {
+    .header-left .logo {
+      font-size: 1.3rem;
+      font-weight: bold;
+    }
+    .header-left nav a {
       text-decoration: none;
       color: #333;
       margin-right: 1rem;
+      font-weight: 500;
     }
-    .header-buttons button {
-      padding: 0.5rem 1rem;
-      border-radius: 4px;
-      background-color: #000;
-      color: #fff;
-      border: none;
+    .header-left nav a:hover {
+      color: #000;
+    }
+    .header-left nav a.active {
+      color: #000;
+      border-bottom: 2px solid #000;
+      padding-bottom: 3px;
+    }
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+    .header-right span {
+      font-size: 1.2rem;
       cursor: pointer;
+    }
+    .btn-primary {
+      background-color: #000;
+      color: white;
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: 500;
+    }
+    .btn-primary:hover {
+      background-color: #333;
     }
     .container {
       display: grid;
@@ -48,24 +76,72 @@
     .profile-section, .stats-section {
       border: 1px solid #eee;
       border-radius: 8px;
-      padding: 1rem;
-      margin-bottom: 1rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+      background-color: #fff;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
     }
     .profile-section img {
-      width: 80px;
-      height: 80px;
+      width: 100px;
+      height: 100px;
       border-radius: 50%;
       background-color: #f0f0f0;
       display: block;
-      margin-bottom: 1rem;
+      margin: 0 auto 1rem;
+      object-fit: cover;
+    }
+    .profile-section h3 {
+      text-align: center;
+      margin-bottom: 0.5rem;
+    }
+    .profile-temperature {
+      text-align: center;
+      font-size: 1.1rem;
+      margin-bottom: 1.5rem;
+    }
+    .profile-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+    .profile-actions button {
+      padding: 0.7rem 1rem;
+      border-radius: 4px;
+      background-color: #f5f5f5;
+      color: #333;
+      border: 1px solid #ddd;
+      cursor: pointer;
+      font-weight: 500;
+    }
+    .profile-actions button:hover {
+      background-color: #eee;
+    }
+    .profile-actions button.danger {
+      background-color: #fff;
+      color: #ff3b30;
+      border: 1px solid #ff3b30;
+    }
+    .profile-actions button.danger:hover {
+      background-color: #fff0f0;
     }
     .main-section {
       border: 1px solid #eee;
       border-radius: 8px;
-      padding: 1rem;
+      padding: 1.5rem;
+      background-color: #fff;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+      margin-bottom: 2rem;
     }
     .main-section h2 {
-      margin-bottom: 1rem;
+      margin-bottom: 1.5rem;
+      border-bottom: 1px solid #eee;
+      padding-bottom: 0.5rem;
+    }
+    .tabs {
+      display: flex;
+      margin-bottom: 1.5rem;
+      border-bottom: 1px solid #eee;
+      padding-bottom: 1rem;
     }
     .tabs button {
       padding: 0.5rem 1rem;
@@ -75,26 +151,210 @@
       margin-right: 0.5rem;
       border-radius: 4px;
     }
+    .tabs button.active {
+      background-color: #000;
+      color: #fff;
+      border-color: #000;
+    }
+    .tabs button:hover:not(.active) {
+      background-color: #f5f5f5;
+    }
+    .tabs button.create-meeting {
+      margin-left: auto;
+      background-color: #000;
+      color: #fff;
+      border-color: #000;
+    }
+    .tabs button.create-meeting:hover {
+      background-color: #333;
+    }
     .meeting-item {
       border: 1px solid #eee;
       border-radius: 8px;
-      padding: 1rem;
+      padding: 1.2rem;
       margin: 1rem 0;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    .meeting-item:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 6px rgba(0,0,0,0.1);
     }
     .meeting-item h4 {
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.7rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
     }
     .meeting-item p {
       font-size: 0.9rem;
       color: #666;
-      margin-bottom: 0.3rem;
+      margin-bottom: 0.5rem;
     }
     .meeting-item a {
-      color: #007bff;
+      color: #000;
       text-decoration: none;
       font-size: 0.9rem;
+      font-weight: 500;
+    }
+    .meeting-item a:hover {
+      text-decoration: underline;
+    }
+    .status-badge {
+      background-color: #eee;
+      padding: 0.2rem 0.7rem;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      font-weight: 500;
+    }
+    .status-badge.active {
+      background-color: #000;
+      color: #fff;
+    }
+    .status-badge.completed {
+      background-color: #8e8e93;
+      color: #fff;
+    }
+    .mypage-section {
+      margin-bottom: 2rem;
+    }
+    .reviews-section {
+      margin-top: 2rem;
+    }
+    .review-item {
+      border: 1px solid #eee;
+      border-radius: 8px;
+      padding: 1.2rem;
+      margin: 1rem 0;
+    }
+    .review-item .restaurant {
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+    .review-item .rating {
+      color: #000;
+      margin-bottom: 0.5rem;
+    }
+    .review-text {
+      color: #666;
+      margin-bottom: 0.5rem;
+    }
+    .modal {
+      display: none;
+      position: fixed;
+      z-index: 1000;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0,0,0,0.5);
+    }
+    .modal-content {
+      background-color: #fff;
+      margin: 15% auto;
+      padding: 2rem;
+      border-radius: 8px;
+      width: 400px;
+      max-width: 90%;
+      box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+    }
+    .modal-title {
+      margin-bottom: 1rem;
+      font-weight: 500;
+    }
+    .modal-body {
+      margin-bottom: 1.5rem;
+    }
+    .modal-body input {
+      width: 100%;
+      padding: 0.7rem;
+      margin-top: 0.5rem;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      box-sizing: border-box;
+    }
+    .modal-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+    .modal-footer button {
+      padding: 0.7rem 1rem;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: 500;
+    }
+    .modal-footer .cancel {
+      background-color: #f5f5f5;
+      border: 1px solid #ddd;
+      color: #333;
+    }
+    .modal-footer .confirm {
+      background-color: #ff3b30;
+      color: #fff;
+      border: none;
+    }
+    .info-item {
+      margin-bottom: 0.7rem;
+    }
+    .info-item strong {
+      display: inline-block;
+      width: 120px;
+      color: #666;
+    }
+    .preference-items {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+    .preference-tag {
+      display: inline-block;
+      background-color: #f5f5f5;
+      padding: 0.3rem 0.7rem;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      color: #333;
+    }
+    .map-container {
+      height: 300px;
+      background-color: #f5f5f5;
+      border-radius: 8px;
+      margin-top: 1rem;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      color: #888;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 2rem;
+      color: #888;
+    }
+    .preference-section {
+      margin-top: 1rem;
+    }
+    .preference-section h4 {
+      margin-bottom: 0.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .preference-section h4 a {
+      font-size: 0.8rem;
+      color: #000;
+      text-decoration: none;
+    }
+    footer {
+      margin-top: 5rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #999;
+      padding: 1rem 0;
+      border-top: 1px solid #eee;
+      background-color: #fff;
     }
   </style>
+  <script th:src="@{/js/auth.js}"></script>
 </head>
 <body>
 <header>
@@ -102,71 +362,281 @@
     <div class="logo">맛남</div>
     <nav>
       <a th:href="@{/}">홈</a>
-      <a th:href="@{/meetings}">모임 찾기</a>
-      <a th:href="@{/restaurants}">맛집 탐색</a>
-      <a th:href="@{/profile}">마이페이지</a>
+      <a th:href="@{/team/list}">모임 찾기</a>
+      <a th:href="@{/map}">맛집 탐색</a>
+      <a th:href="@{/user/mypage}" class="active">마이페이지</a>
     </nav>
   </div>
-  <div class="header-buttons">
-    <button th:onclick="'location.href=\'' + @{/meeting/create} + '\''">모임 만들기</button>
+  <div class="header-right">
+    <span title="알림">🔔</span>
+    <span title="프로필">👤</span>
+    <button class="btn-primary" th:onclick="'location.href=\'' + @{/team/create} + '\''">모임 만들기</button>
   </div>
 </header>
 
 <div class="container">
-  <!-- 왼쪽: 프로필 & 통계 -->
   <div>
     <div class="profile-section">
-      <img src="#" alt="프로필 이미지">
-      <h3>맛있는사람</h3>
-      <p>🌡️ 맛남온도: 35°C</p>
-      <button>프로필 수정</button>
+      <!-- 추후 User에 유저 이미지가 추가되면 들어갈 부분 -->
+      <h3 th:text="${user.nickname}">맛있는사람</h3>
+      <p class="profile-temperature">매너온도: <span th:text="${user.temperature}">36.5</span>°C</p>
+      <div class="profile-actions">
+        <button onclick="location.href='/user/password/change'">비밀번호 변경</button>
+        <button class="danger" onclick="showDeactivateModal()">회원 탈퇴</button>
+      </div>
     </div>
+
     <div class="profile-section">
       <h4>내 정보</h4>
-      <p><strong>자기소개:</strong> 맛있는 음식을 사랑하는 회원입니다.</p>
-      <p><strong>선호하는 카테고리:</strong> 카페, 한식</p>
-      <p><strong>선호하는 지역:</strong> 강남, 홍대</p>
-      <p><strong>최근 참여 모임:</strong> 강남 맛집 탐방</p>
+      <div class="info-item">
+        <strong>이메일:</strong> <span th:text="${user.email}">user@example.com</span>
+      </div>
+      <div class="info-item">
+        <strong>주소:</strong> <span th:text="${user.address ?: '주소가 등록되지 않았습니다.'}">서울시 강남구</span>
+      </div>
+      <div class="info-item">
+        <strong>가입일:</strong> <span th:text="${#temporals.format(user.createdAt, 'yyyy-MM-dd')}">2023-01-01</span>
+      </div>
+
+      <div class="preference-section">
+        <h4>
+          선호하는 장소
+          <a th:href="@{/user/preference}">수정</a>
+        </h4>
+        <div class="preference-items" th:if="${user.preference != null}">
+          <span class="preference-tag" th:if="${user.preference.goodTalk}">💬 대화하기 좋은</span>
+          <span class="preference-tag" th:if="${user.preference.manyDrink}">🍺 술이 다양한</span>
+          <span class="preference-tag" th:if="${user.preference.goodMusic}">🎵 음악이 좋은</span>
+          <span class="preference-tag" th:if="${user.preference.clean}">✨ 깨끗한</span>
+          <span class="preference-tag" th:if="${user.preference.goodView}">🏞️ 뷰가 좋은</span>
+          <span class="preference-tag" th:if="${user.preference.terrace}">🪑 테라스가 있는</span>
+          <span class="preference-tag" th:if="${user.preference.goodPicture}">📸 사진이 잘 나오는</span>
+          <span class="preference-tag" th:if="${user.preference.goodMenu}">🍽️ 메뉴가 다양한</span>
+          <span class="preference-tag" th:if="${user.preference.longStay}">⏱️ 오래 머물 수 있는</span>
+          <span class="preference-tag" th:if="${user.preference.bigStore}">🏢 매장이 넓은</span>
+        </div>
+        <div class="preference-items" th:if="${user.preference == null}">
+          <p>아직 취향 설정을 하지 않았습니다. <a th:href="@{/user/preference}">취향 설정하기</a></p>
+        </div>
+      </div>
     </div>
+
     <div class="stats-section">
       <h4>활동 통계</h4>
-      <p>주최한 모임: 5회</p>
-      <p>참여한 모임: 12회</p>
-      <p>함께한 맛집: 8곳</p>
+      <p>주최한 모임: <span th:text="${stats.hostingCount}">5</span>회</p>
+      <p>참여한 모임: <span th:text="${stats.participatingCount}">12</span>회</p>
+      <p>함께한 맛집: <span th:text="${stats.restaurantCount}">8</span>곳</p>
     </div>
   </div>
 
-  <!-- 오른쪽: 내 모임 목록 -->
-  <div class="main-section">
-    <h2>내 모임 목록</h2>
-    <div class="tabs">
-      <button>전체</button>
-      <button>주최 중</button>
-      <button>참여 중</button>
-      <button style="float: right;">모임 만들기</button>
+  <!-- 내 모임 목록 -->
+  <div>
+    <div class="main-section mypage-section">
+      <h2>내 모임 목록</h2>
+      <div class="tabs">
+        <button class="active" onclick="switchTab('all')">전체</button>
+        <button onclick="switchTab('hosting')">주최 중</button>
+        <button onclick="switchTab('participating')">참여 중</button>
+        <button onclick="switchTab('completed')">완료됨</button>
+        <button class="create-meeting" onclick="location.href='/team/create'">모임 만들기</button>
+      </div>
+
+      <div id="meetings-container">
+        <!-- 모임이 없을 때 표시할 내용 -->
+        <div th:if="${#lists.isEmpty(allTeams)}" class="empty-state">
+          <p>아직 참여하거나 주최한 모임이 없습니다.</p>
+          <p>모임을 만들거나 다른 사용자의 모임에 참여해보세요!</p>
+        </div>
+
+        <!-- 모임 목록 -->
+        <div th:each="team : ${allTeams}" class="meeting-item">
+          <h4>
+            <span th:text="${team.teamTitle}">모임 제목</span>
+            <span th:if="${team.user.userId == #authentication.name}" class="status-badge active">주최중</span>
+            <span th:unless="${team.user.userId == #authentication.name}" class="status-badge">참여중</span>
+          </h4>
+          <p>📅 <span th:text="${#temporals.format(team.meetDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
+          <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
+          <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
+          <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a>
+        </div>
+      </div>
     </div>
 
-    <div class="meeting-item">
-      <h4>강남 맛집 탐방 모임 <span style="background-color: #eee; padding: 0.2rem 0.5rem; border-radius: 4px;">참여</span></h4>
-      <p>📅 2023년 6월 15일 (목)</p>
-      <p>📍 서울 강남구 언주로</p>
-      <a href="#">자세히</a>
+    <!-- 내 맛집 지도 -->
+    <div class="main-section mypage-section">
+      <h2>내 맛집 지도</h2>
+      <div class="tabs">
+        <button class="active" onclick="switchMapTab('all')">전체</button>
+        <button onclick="switchMapTab('korean')">한식</button>
+        <button onclick="switchMapTab('japanese')">일식</button>
+        <button onclick="switchMapTab('chinese')">중식</button>
+        <button onclick="switchMapTab('western')">양식</button>
+        <button onclick="switchMapTab('cafe')">카페</button>
+        <button class="create-meeting" onclick="location.href='/map/add'">맛집 등록</button>
+      </div>
+
+      <div id="maps-container">
+        <!-- 맛집 지도가 없을 때 표시할 내용 -->
+        <div th:if="${#lists.isEmpty(userMaps)}" class="empty-state">
+          <p>아직 등록한 맛집이 없습니다.</p>
+          <p>나만의 맛집을 등록하고 지도에서 관리해보세요!</p>
+        </div>
+
+        <!-- 맛집 목록 -->
+        <div th:unless="${#lists.isEmpty(userMaps)}" class="map-container">
+          <!-- 여기에 카카오맵 API 활용하여 맛집 위치 표시 -->
+          <div id="map-view" style="width:100%; height:300px;"></div>
+
+          <!-- 맛집 리스트 -->
+          <div th:each="map : ${userMaps}" class="restaurant-item" style="margin-top: 1rem;">
+            <h4 th:text="${map.restaurant.name}">맛집 이름</h4>
+            <p th:text="${map.restaurant.address}">맛집 주소</p>
+            <p>카테고리: <span th:text="${map.restaurant.category}">카테고리</span></p>
+          </div>
+        </div>
+      </div>
     </div>
 
-    <div class="meeting-item">
-      <h4>홍대 이탈리안 파스타 모임 <span style="background-color: #eee; padding: 0.2rem 0.5rem; border-radius: 4px;">완료</span></h4>
-      <p>📅 2023년 6월 19일 (월)</p>
-      <p>📍 서울 마포구 와우산로</p>
-      <a href="#">자세히</a>
-    </div>
+    <!-- 모임 리뷰 -->
+    <div class="main-section reviews-section">
+      <h2>내 리뷰</h2>
 
-    <div class="meeting-item">
-      <h4>을지로 숨은 맛집 탐방 <span style="background-color: #eee; padding: 0.2rem 0.5rem; border-radius: 4px;">완료</span></h4>
-      <p>📅 2023년 6월 20일 (화)</p>
-      <p>📍 서울 중구 충무로</p>
-      <a href="#">자세히</a>
+      <div id="reviews-container">
+        <!-- 리뷰가 없을 때 표시할 내용 -->
+        <div th:if="${#lists.isEmpty(userReviews)}" class="empty-state">
+          <p>아직 작성한 리뷰가 없습니다.</p>
+          <p>모임에 참여하여 리뷰를 남겨보세요!</p>
+        </div>
+
+        <!-- 리뷰 목록 -->
+        <div th:each="review : ${userReviews}" class="review-item">
+          <div class="restaurant" th:text="${review.team.restaurantName}">맛집 이름</div>
+          <div class="rating">
+            <span th:text="${'★'.repeat(review.rating) + '☆'.repeat(5 - review.rating)}">★★★★☆</span>
+            <span th:text="${review.rating}">4.0</span>
+          </div>
+          <div class="review-text" th:text="${review.content}">리뷰 내용</div>
+          <p>📅 <span th:text="${#temporals.format(review.createdAt, 'yyyy년 MM월 dd일')}">2023년 6월 19일</span></p>
+        </div>
+      </div>
     </div>
   </div>
 </div>
-</body>
-</html>
+
+<div id="deactivateModal" class="modal">
+  <div class="modal-content">
+    <h3 class="modal-title">회원 탈퇴</h3>
+    <form id="deactivateForm" action="/user/deactivate" method="post">
+      <div class="modal-body">
+        <p>정말로 회원 탈퇴를 진행하시겠습니까? 탈퇴 후에는 계정을 복구할 수 없습니다.</p>
+        <p>비밀번호를 입력하여 탈퇴를 확인해주세요.</p>
+        <input type="password" id="deactivatePassword" name="password" placeholder="비밀번호">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="cancel" onclick="hideDeactivateModal()">취소</button>
+        <button type="submit" class="confirm">탈퇴하기</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<footer>
+  © 2025 맛남. 모든 권리 보유.
+</footer>
+
+<script>
+  function showDeactivateModal() {
+    document.getElementById('deactivateModal').style.display = 'block';
+  }
+
+  function hideDeactivateModal() {
+    document.getElementById('deactivateModal').style.display = 'none';
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('deactivateForm').addEventListener('submit', function(e) {
+      if(!confirm('정말로 탈퇴하시겠습니까? 이 작업은 되돌릴 수 없습니다.')) {
+        e.preventDefault();
+      }
+    });
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const error = urlParams.get('error');
+    if (error) {
+      alert('회원 탈퇴 중 오류가 발생했습니다: ' + error);
+    }
+
+    window.onclick = function(event) {
+      const modal = document.getElementById('deactivateModal');
+      if (event.target === modal) {
+        hideDeactivateModal();
+      }
+    }
+
+    if (!auth.isLoggedIn()) {
+      window.location.href = '/user/signin';
+      return;
+    }
+  });
+
+  // 모임 목록 탭 전환
+  function switchTab(tabName) {
+    // 탭 버튼 활성화 상태 변경
+    const tabButtons = document.querySelectorAll('.tabs button:not(.create-meeting)');
+    tabButtons.forEach(button => {
+      button.classList.remove('active');
+    });
+    event.target.classList.add('active');
+
+    // 모임 아이템 필터링
+    const meetingItems = document.querySelectorAll('#meetings-container .meeting-item');
+    const emptyState = document.querySelector('#meetings-container .empty-state');
+
+    let visibleCount = 0;
+
+    meetingItems.forEach(item => {
+      const statusBadge = item.querySelector('.status-badge');
+      const isHosting = statusBadge && statusBadge.textContent.includes('주최중');
+      const isParticipating = statusBadge && statusBadge.textContent.includes('참여중');
+      const isCompleted = statusBadge && statusBadge.textContent.includes('완료');
+
+      if (tabName === 'all') {
+        item.style.display = 'block';
+        visibleCount++;
+      } else if (tabName === 'hosting' && isHosting) {
+        item.style.display = 'block';
+        visibleCount++;
+      } else if (tabName === 'participating' && isParticipating) {
+        item.style.display = 'block';
+        visibleCount++;
+      } else if (tabName === 'completed' && isCompleted) {
+        item.style.display = 'block';
+        visibleCount++;
+      } else {
+        item.style.display = 'none';
+      }
+    });
+
+    // 표시할 항목이 없으면 empty state 표시
+    if (emptyState) {
+      emptyState.style.display = visibleCount > 0 ? 'none' : 'block';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    if (!auth.isLoggedIn()) {
+      window.location.href = '/user/signin';
+      return;
+    }
+
+    window.onclick = function(event) {
+      const modal = document.getElementById('deactivateModal');
+      if (event.target === modal) {
+        hideDeactivateModal();
+      }
+    }
+
+    // 카카오맵 API 초기화
+  });
+</script>

--- a/src/main/resources/templates/user/passwordChange.html
+++ b/src/main/resources/templates/user/passwordChange.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>맛남 | 비밀번호 변경</title>
+    <style>
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f9f9f9;
+            color: #333;
+        }
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1rem 2rem;
+            border-bottom: 1px solid #eee;
+            background-color: #fff;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 2rem;
+        }
+        .header-left .logo {
+            font-size: 1.3rem;
+            font-weight: bold;
+        }
+        .header-left nav a {
+            text-decoration: none;
+            color: #333;
+            margin-right: 1rem;
+            font-weight: 500;
+        }
+        .header-left nav a:hover {
+            color: #000;
+        }
+        .header-left nav a.active {
+            color: #000;
+            border-bottom: 2px solid #000;
+            padding-bottom: 3px;
+        }
+        .header-right {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+        .header-right span {
+            font-size: 1.2rem;
+            cursor: pointer;
+        }
+        .btn-primary {
+            background-color: #000;
+            color: white;
+            padding: 0.5rem 1rem;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: 500;
+        }
+        .btn-primary:hover {
+            background-color: #333;
+        }
+        .container {
+            max-width: 600px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+        }
+        .password-change-section {
+            border: 1px solid #eee;
+            border-radius: 8px;
+            padding: 2rem;
+            background-color: #fff;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .password-change-section h2 {
+            margin-bottom: 1.5rem;
+            border-bottom: 1px solid #eee;
+            padding-bottom: 0.5rem;
+        }
+        .form-group {
+            margin-bottom: 1.5rem;
+        }
+        .form-group label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: 500;
+        }
+        .form-group input {
+            width: 100%;
+            padding: 0.7rem;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 1rem;
+            box-sizing: border-box;
+        }
+        .form-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 1rem;
+            margin-top: 2rem;
+        }
+        .form-actions .btn-secondary {
+            background-color: #f5f5f5;
+            color: #333;
+            padding: 0.5rem 1rem;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: 500;
+        }
+        .form-actions .btn-secondary:hover {
+            background-color: #eee;
+        }
+        .error-message {
+            color: #ff3b30;
+            font-size: 0.9rem;
+            margin-top: 0.5rem;
+        }
+        .password-rules {
+            margin-top: 0.5rem;
+            font-size: 0.9rem;
+            color: #666;
+        }
+        footer {
+            margin-top: 5rem;
+            text-align: center;
+            font-size: 0.8rem;
+            color: #999;
+            padding: 1rem 0;
+            border-top: 1px solid #eee;
+            background-color: #fff;
+        }
+    </style>
+    <script th:src="@{/js/auth.js}"></script>
+</head>
+<body>
+<header>
+    <div class="header-left">
+        <div class="logo">맛남</div>
+        <nav>
+            <a th:href="@{/}">홈</a>
+            <a th:href="@{/team/list}">모임 찾기</a>
+            <a th:href="@{/map}">맛집 탐색</a>
+            <a th:href="@{/user/mypage}" class="active">마이페이지</a>
+        </nav>
+    </div>
+    <div class="header-right">
+        <span title="알림">🔔</span>
+        <span title="프로필">👤</span>
+        <button class="btn-primary" th:onclick="'location.href=\'' + @{/team/create} + '\''">모임 만들기</button>
+    </div>
+</header>
+
+<div class="container">
+    <div class="password-change-section">
+        <h2>비밀번호 변경</h2>
+        <p>안전한 정보 관리를 위해 주기적으로 비밀번호를 변경해주세요.</p>
+        <form id="passwordForm">
+            <div class="form-group">
+                <label for="currentPassword">현재 비밀번호</label>
+                <input type="password" id="currentPassword" name="currentPassword" required>
+                <div class="error-message" id="currentPassword-error"></div>
+            </div>
+            <div class="form-group">
+                <label for="newPassword">새 비밀번호</label>
+                <input type="password" id="newPassword" name="newPassword" required>
+                <div class="error-message" id="newPassword-error"></div>
+            </div>
+            <div class="form-group">
+                <label for="confirmPassword">새 비밀번호 확인</label>
+                <input type="password" id="confirmPassword" name="confirmPassword" required>
+                <div class="error-message" id="confirmPassword-error"></div>
+            </div>
+            <div class="form-actions">
+                <button type="button" class="btn-secondary" onclick="cancel()">취소</button>
+                <button type="button" class="btn-primary" onclick="changePassword()">변경하기</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<footer>
+    © 2025 맛남. 모든 권리 보유.
+</footer>
+
+<script>
+    function cancel() {
+        window.location.href = '/user/mypage';
+    }
+
+    function changePassword() {
+        const currentPassword = document.getElementById('currentPassword').value;
+        const newPassword = document.getElementById('newPassword').value;
+        const confirmPassword = document.getElementById('confirmPassword').value;
+
+        document.getElementById('currentPassword-error').textContent = '';
+        document.getElementById('newPassword-error').textContent = '';
+        document.getElementById('confirmPassword-error').textContent = '';
+
+        let isValid = true;
+
+        if (!currentPassword) {
+            document.getElementById('currentPassword-error').textContent = '현재 비밀번호를 입력해주세요.';
+            isValid = false;
+        }
+
+        // 8자 이상, 영문/숫자/특수문자 포함
+        const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$/;
+        if (!newPassword) {
+            document.getElementById('newPassword-error').textContent = '새 비밀번호를 입력해주세요.';
+            isValid = false;
+        } else if (!passwordRegex.test(newPassword)) {
+            document.getElementById('newPassword-error').textContent = '비밀번호는 8자 이상, 영문/숫자/특수문자를 포함해야 합니다.';
+            isValid = false;
+        }
+
+        if (!confirmPassword) {
+            document.getElementById('confirmPassword-error').textContent = '새 비밀번호 확인을 입력해주세요.';
+            isValid = false;
+        } else if (newPassword !== confirmPassword) {
+            document.getElementById('confirmPassword-error').textContent = '새 비밀번호와 일치하지 않습니다.';
+            isValid = false;
+        }
+
+        if (isValid) {
+            auth.fetchWithAuth('/api/user/password', {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    currentPassword: currentPassword,
+                    newPassword: newPassword
+                })
+            })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.code === 200) {
+                        alert('비밀번호가 성공적으로 변경되었습니다.');
+                        window.location.href = '/user/mypage';
+                    } else {
+                        if (data.message.includes('현재 비밀번호')) {
+                            document.getElementById('currentPassword-error').textContent = data.message;
+                        } else {
+                            alert(data.message);
+                        }
+                    }
+                    window.location.href = '/user/mypage';
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('비밀번호 변경 중 오류가 발생했습니다.');
+                    window.location.href = '/';
+                });
+        }
+    }
+
+    // TODO: 모임 리뷰
+
+    // TODO: 모임 및 맛집 지도
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/user/signin.html
+++ b/src/main/resources/templates/user/signin.html
@@ -140,6 +140,7 @@
       margin-bottom: 1rem;
     }
   </style>
+  <script th:src="@{/js/auth.js}"></script>
 </head>
 <body>
 
@@ -207,6 +208,7 @@
     };
 
     try {
+      console.log('로그인 시도:', loginData);
       const response = await fetch('/api/user/signin', {
         method: 'POST',
         headers: {
@@ -215,13 +217,14 @@
         body: JSON.stringify(loginData)
       });
 
+      console.log('응답 상태:', response.status);
       const result = await response.json();
+      console.log('응답 데이터:', result);
 
       if (response.ok) {
         if (result.data && result.data.token) {
-          localStorage.setItem('jwtToken', result.data.token);
-          localStorage.setItem('userId', result.data.userId);
-          localStorage.setItem('userRole', result.data.role);
+          auth.setCookie('userId', result.data.userId);
+          auth.setCookie('userRole', result.data.role);
         }
 
         alert('로그인에 성공했습니다!');
@@ -240,7 +243,7 @@
         }
       }
     } catch (error) {
-      console.error('Error during login:', error);
+      console.error('로그인 오류 상세:', error);
       document.getElementById('userIdError').textContent = '서버와 통신 중 오류가 발생했습니다.';
     }
   });


### PR DESCRIPTION
## 📌 과제 설명
회원의 마이페이지와 비밀번호 변경, 탈퇴 기능과 화면을 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용
- "feat: 회원 탈퇴 기능 구현": 회원 탈퇴 API 구현
- "feat: JWT 토큰을 localStorage에서 Cookie로 저장하도록 기능 수정": 토큰을 Cookie에 저장되도록 수정하여 컨트롤러 로직을 간편하게 수정
- "feat: 사용자 패스워드 변경 및 온도 조회 기능 구현": 패스워드 변경 및 온도 조회 API 구현
- "feat: 마이페이지, 비밀번호 변경, 회원 탈퇴 화면 구현": 마이페이지와 비밀번호 변경 화면 및 탈퇴 화면 구현
- "feat: 마이페이지, 회원 탈퇴, 비밀번호 변경 컨트롤러 구현": 해당 기능들의 컨트롤러 구현

