### PR TITLE
feat: 마이페이지 내 개인 맛집 지도 리스트 조회 및 설정 변경 구현

### DIFF
--- a/src/main/java/com/grepp/matnam/app/controller/api/mymap/MymapApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/mymap/MymapApiController.java
@@ -5,8 +5,11 @@ import com.grepp.matnam.app.model.mymap.MymapRepository;
 import com.grepp.matnam.app.model.user.UserService;
 import com.grepp.matnam.app.model.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -42,4 +45,22 @@ public class MymapApiController {
         mymapRepository.save(mymap);
         return "저장 완료";
     }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<String> updatePlace(@PathVariable Long id, @RequestBody Mymap request) {
+        Mymap existing = mymapRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 장소를 찾을 수 없습니다."));
+
+        if (request.getPinned() != null) {
+            existing.setPinned(request.getPinned());
+        }
+
+        if (request.getActivated() != null) {
+            existing.setActivated(request.getActivated());
+        }
+
+        mymapRepository.save(existing);
+        return ResponseEntity.ok("업데이트 완료");
+    }
+
 }

--- a/src/main/java/com/grepp/matnam/app/controller/web/mymap/MymapController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/web/mymap/MymapController.java
@@ -1,15 +1,28 @@
 package com.grepp.matnam.app.controller.web.mymap;
 
+import com.grepp.matnam.app.model.user.UserService;
+import com.grepp.matnam.app.model.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 @RequiredArgsConstructor
 public class MymapController {
 
+    private final UserService userService;
+
     @GetMapping("/map/add")
     public String showAddPage() {
         return "map/add";
+    }
+
+    @GetMapping("/map/editMap")
+    public String showEditMapPage(Model model) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userService.getUserById(userId);
+        return "map/editMap";
     }
 }

--- a/src/main/java/com/grepp/matnam/app/controller/web/mymap/MymapController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/web/mymap/MymapController.java
@@ -26,3 +26,4 @@ public class MymapController {
         return "map/editMap";
     }
 }
+

--- a/src/main/java/com/grepp/matnam/infra/config/SecurityConfig.java
+++ b/src/main/java/com/grepp/matnam/infra/config/SecurityConfig.java
@@ -36,6 +36,12 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
+                // mypage 내에 맵 띄우기 위해 x-frame 옵션 설정을 추가했습니다.
+                .headers(headers->headers
+                        .frameOptions(frameOptions -> frameOptions
+                                .sameOrigin()
+                        )
+                )
                 // #TODO: 접근 제한 추가
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll()

--- a/src/main/resources/templates/map/add.html
+++ b/src/main/resources/templates/map/add.html
@@ -206,7 +206,6 @@
         <div id="pagination"></div>
     </div>
 </div>
-
 <footer>© 2025 맛남. 모든 권리 보유.</footer>
 <script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=9e9f7116c9bee853591bfa6e12c7fa5f&libraries=services"></script>
 <script>

--- a/src/main/resources/templates/map/add.html
+++ b/src/main/resources/templates/map/add.html
@@ -217,19 +217,25 @@
 
     const yellowMarkerImage = new kakao.maps.MarkerImage(
         '/img/map-marker-yellow.png',
-        new kakao.maps.Size(40, 42),
-        { offset: new kakao.maps.Point(20, 42) }
+        new kakao.maps.Size(38, 40),
+        { offset: new kakao.maps.Point(19, 40) }
     );
 
     const blueMarkerImage = new kakao.maps.MarkerImage(
         '/img/map-marker-blue.png',
+        new kakao.maps.Size(38, 40),
+        { offset: new kakao.maps.Point(19, 40) }
+    );
+
+    const redMarkerImage = new kakao.maps.MarkerImage(
+        '/img/map-marker-red.png',
         new kakao.maps.Size(40, 42),
         { offset: new kakao.maps.Point(20, 42) }
     );
 
     function initMap() {
         const container = document.getElementById('map');
-        const options = { center: new kakao.maps.LatLng(37.5665, 126.9780), level: 3, minLevel: 1 };
+        const options = { center: new kakao.maps.LatLng(37.48453710546348, 127.01083175248992), level: 1, minLevel: 1 };
         map = new kakao.maps.Map(container, options);
 
         kakao.maps.event.addListener(map, 'click', function(mouseEvent) {
@@ -244,7 +250,7 @@
             clickedMarker = new kakao.maps.Marker({
                 position: latlng,
                 map: map,
-                image: blueMarkerImage
+                image: redMarkerImage
             });
 
             moveMapTo(latlng);
@@ -376,7 +382,7 @@
 
         if (clickedMarker) clickedMarker.setMap(null);
         const pos = new kakao.maps.LatLng(place.y, place.x);
-        clickedMarker = new kakao.maps.Marker({ map, position: pos, image: blueMarkerImage });
+        clickedMarker = new kakao.maps.Marker({ map, position: pos, image: redMarkerImage });
 
         kakao.maps.event.addListener(clickedMarker, 'click', () => {
             fillFormWithPlace(place);
@@ -441,7 +447,7 @@
                     myPlaceMarkers.push(marker);
                 });
 
-                // 저장된 장소가 하나 이상일 경우 해당 영역으로 지도 확대 및 이동
+                // 저장된 장소가 하나 이상일 경우 해당 영역 중심으로 지도 확대 및 이동
                 if (!bounds.isEmpty()) {
                     map.setBounds(bounds);
                 }

--- a/src/main/resources/templates/map/editMap.html
+++ b/src/main/resources/templates/map/editMap.html
@@ -10,8 +10,8 @@
             padding: 20px;
         }
 
-        h2 {
-            margin-bottom: 20px;
+        h4, h5 {
+            margin: 0 0 1rem;
         }
 
         #map {
@@ -39,6 +39,15 @@
             flex: 1;
         }
 
+        .place-info strong {
+            cursor: pointer;
+            color: #007bff;
+        }
+
+        .place-info strong:hover {
+            text-decoration: underline;
+        }
+
         .place-actions button {
             margin-left: 5px;
             padding: 5px 10px;
@@ -54,8 +63,8 @@
     </style>
 </head>
 <body>
-<h4 style="margin-top:0.5rem;"> 저장된 맛집 리스트를 삭제하거나 숨김여부를 선택해주세요 </h4>
-<h5 style="margin-top:0; margin-bottom: 1rem;">💙파란핀: 공개 | 💛노란핀 : 비공개</h5>
+<h4>저장된 맛집 리스트를 조회하고 삭제 또는 공개여부를 선택해주세요</h4>
+<h5>💙파란핀: 공개 | 💛노란핀 : 비공개</h5>
 <div id="map"></div>
 <div id="placeList"></div>
 
@@ -74,6 +83,13 @@
     );
 
     let map;
+    let markers = [];
+    let overlays = [];
+
+    function closeAllOverlays() {
+        overlays.forEach(o => o.setMap(null));
+        overlays = [];
+    }
 
     function initMap(places) {
         const mapContainer = document.getElementById('map');
@@ -85,6 +101,9 @@
 
         const bounds = new kakao.maps.LatLngBounds();
 
+        markers = []; // 초기화
+        overlays = [];
+
         places.forEach(place => {
             const pos = new kakao.maps.LatLng(place.latitude, place.longitude);
             const marker = new kakao.maps.Marker({
@@ -92,6 +111,25 @@
                 position: pos,
                 image: place.pinned ? blueMarkerImage : yellowMarkerImage
             });
+
+            const overlayContent = `
+                <div style="padding:5px 10px; background:#fff; border:1px solid #ccc; border-radius:4px;">
+                    ${place.placeName}
+                </div>`;
+            const overlay = new kakao.maps.CustomOverlay({
+                content: overlayContent,
+                position: pos,
+                yAnchor: 1.5
+            });
+
+            marker.addListener('click', () => {
+                closeAllOverlays();
+                overlay.setMap(map);
+                map.setCenter(pos);
+                overlays.push(overlay);
+            });
+
+            markers.push({ id: place.mapId, marker, pos, overlay });
 
             bounds.extend(pos);
         });
@@ -108,23 +146,47 @@
         places.forEach(place => {
             const item = document.createElement('div');
             item.className = 'place-item';
-            item.dataset.id = place.id;
+            item.dataset.id = place.mapId;
             item.dataset.pinned = place.pinned;
 
-            item.innerHTML = `
-                <div class="place-info">
-                    <strong>${place.placeName}</strong><br />
-                    <small>${place.roadAddress}</small>
-                </div>
-                <div class="place-actions">
-                    <button onclick="updatePlace(${place.mapId}, true)">공개</button>
-                    <button onclick="updatePlace(${place.mapId}, false)">숨김</button>
-                    <button onclick="deletePlace(${place.mapId})">삭제</button>
-                </div>
-            `;
+            const infoDiv = document.createElement('div');
+            infoDiv.className = 'place-info';
+
+            const nameEl = document.createElement('strong');
+            nameEl.innerText = place.placeName;
+            nameEl.style.cursor = 'pointer';
+            nameEl.style.color = 'inherit'; // ✅ 검정색 유지
+            nameEl.onclick = () => {
+                const target = markers.find(m => m.id === place.mapId);
+                if (target) {
+                    closeAllOverlays();
+                    target.overlay.setMap(map);
+                    map.setCenter(target.pos);
+                    overlays.push(target.overlay);
+                }
+            };
+
+            const addressEl = document.createElement('small');
+            addressEl.innerText = place.roadAddress;
+
+            infoDiv.appendChild(nameEl);
+            infoDiv.appendChild(document.createElement('br'));
+            infoDiv.appendChild(addressEl);
+
+            const actionsDiv = document.createElement('div');
+            actionsDiv.className = 'place-actions';
+            actionsDiv.innerHTML = `
+            <button onclick="updatePlace(${place.mapId}, true)">공개</button>
+            <button onclick="updatePlace(${place.mapId}, false)">숨김</button>
+            <button onclick="deletePlace(${place.mapId})">삭제</button>
+        `;
+
+            item.appendChild(infoDiv);
+            item.appendChild(actionsDiv);
             container.appendChild(item);
         });
     }
+
 
     function updatePlace(id, isPinned) {
         const item = document.querySelector(`.place-item[data-id="${id}"]`);
@@ -186,9 +248,8 @@
         })
         .catch(err => {
             alert("장소 정보를 불러오지 못했습니다.");
-            console.error(err);
+            console.error("에러:", err);
         });
 </script>
-
 </body>
 </html>

--- a/src/main/resources/templates/map/editMap.html
+++ b/src/main/resources/templates/map/editMap.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>맛남 | 마이페이지 - 수정 | 맛집 지도 & 리스트</title>
+    <style>
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+            margin: 0;
+            padding: 20px;
+        }
+
+        h2 {
+            margin-bottom: 20px;
+        }
+
+        #map {
+            width: 100%;
+            height: 400px;
+            border: 1px solid #ccc;
+            border-radius: 8px;
+        }
+
+        #placeList {
+            margin-top: 20px;
+            border-top: 1px solid #ddd;
+            padding-top: 15px;
+        }
+
+        .place-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px 0;
+            border-bottom: 1px solid #eee;
+        }
+
+        .place-info {
+            flex: 1;
+        }
+
+        .place-actions button {
+            margin-left: 5px;
+            padding: 5px 10px;
+            border: none;
+            background-color: #eee;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .place-actions button:hover {
+            background-color: #ddd;
+        }
+    </style>
+</head>
+<body>
+<h4 style="margin-top:0.5rem;"> 저장된 맛집 리스트를 삭제하거나 숨김여부를 선택해주세요 </h4>
+<h5 style="margin-top:0; margin-bottom: 1rem;">💙파란핀: 공개 | 💛노란핀 : 비공개</h5>
+<div id="map"></div>
+<div id="placeList"></div>
+
+<script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=9e9f7116c9bee853591bfa6e12c7fa5f&libraries=services"></script>
+<script>
+    const yellowMarkerImage = new kakao.maps.MarkerImage(
+        '/img/map-marker-yellow.png',
+        new kakao.maps.Size(38, 40),
+        { offset: new kakao.maps.Point(19, 40) }
+    );
+
+    const blueMarkerImage = new kakao.maps.MarkerImage(
+        '/img/map-marker-blue.png',
+        new kakao.maps.Size(38, 40),
+        { offset: new kakao.maps.Point(19, 40) }
+    );
+
+    let map;
+
+    function initMap(places) {
+        const mapContainer = document.getElementById('map');
+        const mapOption = {
+            center: new kakao.maps.LatLng(37.5665, 126.9780),
+            level: 4
+        };
+        map = new kakao.maps.Map(mapContainer, mapOption);
+
+        const bounds = new kakao.maps.LatLngBounds();
+
+        places.forEach(place => {
+            const pos = new kakao.maps.LatLng(place.latitude, place.longitude);
+            const marker = new kakao.maps.Marker({
+                map,
+                position: pos,
+                image: place.pinned ? blueMarkerImage : yellowMarkerImage
+            });
+
+            bounds.extend(pos);
+        });
+
+        if (!bounds.isEmpty()) {
+            map.setBounds(bounds);
+        }
+    }
+
+    function renderPlaceList(places) {
+        const container = document.getElementById('placeList');
+        container.innerHTML = '';
+
+        places.forEach(place => {
+            const item = document.createElement('div');
+            item.className = 'place-item';
+            item.dataset.id = place.id;
+            item.dataset.pinned = place.pinned;
+
+            item.innerHTML = `
+                <div class="place-info">
+                    <strong>${place.placeName}</strong><br />
+                    <small>${place.roadAddress}</small>
+                </div>
+                <div class="place-actions">
+                    <button onclick="updatePlace(${place.mapId}, true)">공개</button>
+                    <button onclick="updatePlace(${place.mapId}, false)">숨김</button>
+                    <button onclick="deletePlace(${place.mapId})">삭제</button>
+                </div>
+            `;
+            container.appendChild(item);
+        });
+    }
+
+    function updatePlace(id, isPinned) {
+        const item = document.querySelector(`.place-item[data-id="${id}"]`);
+        if (!item) {
+            alert("장소 정보를 찾을 수 없습니다.");
+            return;
+        }
+
+        const currentPinned = item.dataset.pinned === 'true';
+        if (currentPinned === isPinned) {
+            alert(isPinned ? "이미 공개된 장소입니다." : "이미 숨김 처리된 장소입니다.");
+            return;
+        }
+
+        fetch('/api/mymap/' + id, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ pinned: isPinned })
+        }).then(res => {
+            if (!res.ok) throw new Error("업데이트 실패");
+            alert(isPinned ? "공개로 설정되었습니다." : "숨김 처리되었습니다.");
+            location.reload();
+        }).catch(err => alert("에러: " + err.message));
+    }
+
+    function deletePlace(id) {
+        if (!confirm("정말로 이 장소를 삭제하시겠습니까?")) return;
+
+        fetch('/api/mymap/' + id, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ activated: false })
+        }).then(res => {
+            if (!res.ok) throw new Error("삭제 실패");
+            alert("삭제되었습니다.");
+            location.reload();
+        }).catch(err => alert("에러: " + err.message));
+    }
+
+    fetch('/api/mymap/activated', {
+        credentials: 'include'
+    })
+        .then(async res => {
+            const contentType = res.headers.get("Content-Type");
+            if (!res.ok) {
+                const errorText = await res.text();
+                throw new Error(`서버 응답 오류: ${res.status} \n${errorText}`);
+            }
+            if (!contentType.includes("application/json")) {
+                throw new Error("JSON이 아닌 응답 형식입니다.");
+            }
+            return res.json();
+        })
+        .then(data => {
+            initMap(data);
+            renderPlaceList(data);
+        })
+        .catch(err => {
+            alert("장소 정보를 불러오지 못했습니다.");
+            console.error(err);
+        });
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/map/editMap.html
+++ b/src/main/resources/templates/map/editMap.html
@@ -41,7 +41,7 @@
 
         .place-info strong {
             cursor: pointer;
-            color: #007bff;
+            color: inherit;
         }
 
         .place-info strong:hover {
@@ -95,13 +95,12 @@
         const mapContainer = document.getElementById('map');
         const mapOption = {
             center: new kakao.maps.LatLng(37.5665, 126.9780),
-            level: 4
+            level: 3
         };
         map = new kakao.maps.Map(mapContainer, mapOption);
 
         const bounds = new kakao.maps.LatLngBounds();
-
-        markers = []; // 초기화
+        markers = [];
         overlays = [];
 
         places.forEach(place => {
@@ -126,11 +125,11 @@
                 closeAllOverlays();
                 overlay.setMap(map);
                 map.setCenter(pos);
+                map.setLevel(3); // 확대
                 overlays.push(overlay);
             });
 
             markers.push({ id: place.mapId, marker, pos, overlay });
-
             bounds.extend(pos);
         });
 
@@ -155,13 +154,14 @@
             const nameEl = document.createElement('strong');
             nameEl.innerText = place.placeName;
             nameEl.style.cursor = 'pointer';
-            nameEl.style.color = 'inherit'; // ✅ 검정색 유지
+            nameEl.style.color = 'inherit';
             nameEl.onclick = () => {
                 const target = markers.find(m => m.id === place.mapId);
                 if (target) {
                     closeAllOverlays();
                     target.overlay.setMap(map);
                     map.setCenter(target.pos);
+                    map.setLevel(3); // 확대
                     overlays.push(target.overlay);
                 }
             };
@@ -176,17 +176,16 @@
             const actionsDiv = document.createElement('div');
             actionsDiv.className = 'place-actions';
             actionsDiv.innerHTML = `
-            <button onclick="updatePlace(${place.mapId}, true)">공개</button>
-            <button onclick="updatePlace(${place.mapId}, false)">숨김</button>
-            <button onclick="deletePlace(${place.mapId})">삭제</button>
-        `;
+                <button onclick="updatePlace(${place.mapId}, true)">공개</button>
+                <button onclick="updatePlace(${place.mapId}, false)">숨김</button>
+                <button onclick="deletePlace(${place.mapId})">삭제</button>
+            `;
 
             item.appendChild(infoDiv);
             item.appendChild(actionsDiv);
             container.appendChild(item);
         });
     }
-
 
     function updatePlace(id, isPinned) {
         const item = document.querySelector(`.place-item[data-id="${id}"]`);

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -377,14 +377,11 @@
     }
 
     .map-container {
-      height: 300px;
-      background-color: #f5f5f5;
+      height: 600px;
+      background-color: transparent;
       border-radius: 8px;
-      margin-top: 1rem;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: #888;
+      padding: 0;
+      overflow: hidden;
     }
 
     .empty-state {
@@ -623,37 +620,34 @@
         </div>
       </div>
     </div>
-
-    <!-- 내 맛집 지도 -->
-    <div class="main-section mypage-section">
-      <h2>내 맛집 지도</h2>
-      <div class="tabs">
-        <button class="active" onclick="switchMapTab('all')">전체</button>
-        <button onclick="switchMapTab('korean')">한식</button>
-        <button onclick="switchMapTab('japanese')">일식</button>
-        <button onclick="switchMapTab('chinese')">중식</button>
-        <button onclick="switchMapTab('western')">양식</button>
-        <button onclick="switchMapTab('cafe')">카페</button>
-        <button class="create-meeting" onclick="location.href='/map/add'">맛집 등록</button>
-      </div>
-
-      <div id="maps-container">
-        <!-- 맛집 지도가 없을 때 표시할 내용 -->
-        <div th:if="${#lists.isEmpty(userMaps)}" class="empty-state">
-          <p>아직 등록한 맛집이 없습니다.</p>
-          <p>나만의 맛집을 등록하고 지도에서 관리해보세요!</p>
+      <!-- 내 맛집 지도 -->
+      <div class="main-section mypage-section">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+          <h2 style="margin-bottom: 0;">내 맛집 지도</h2>
+          <button onclick="location.href='/map/add'"
+                  style="
+          background: #000;
+          color: #fff;
+          border: none;
+          padding: 8px 14px;
+          font-weight: bold;
+          border-radius: 4px;
+          cursor: pointer;
+          transition: background 0.2s ease, transform 0.2s ease;"
+                  onmouseover="this.style.background='#333'; this.style.transform='translateY(-1px)'"
+                  onmouseout="this.style.background='#000'; this.style.transform='none'">
+            맛집 등록
+          </button>
         </div>
-
-        <!-- 맛집 목록 -->
-        <div th:unless="${#lists.isEmpty(userMaps)}" class="map-container">
-          <!-- 여기에 카카오맵 API 활용하여 맛집 위치 표시 -->
-          <div id="map-view" style="width:100%; height:300px;"></div>
-
-          <!-- 맛집 리스트 -->
-          <div th:each="map : ${userMaps}" class="restaurant-item" style="margin-top: 1rem;">
-            <h4 th:text="${map.restaurant.name}">맛집 이름</h4>
-            <p th:text="${map.restaurant.address}">맛집 주소</p>
-            <p>카테고리: <span th:text="${map.restaurant.category}">카테고리</span></p>
+        <div id="map-container">
+          <div class="map-container">
+            <iframe th:src="@{/map/editMap}"
+                    width="100%"
+                    height="600px"
+                    style="border: none;
+                    border-radius: 8px;
+                    overflow: hidden;">
+            </iframe>
           </div>
         </div>
       </div>

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -636,7 +636,7 @@
           transition: background 0.2s ease, transform 0.2s ease;"
                   onmouseover="this.style.background='#333'; this.style.transform='translateY(-1px)'"
                   onmouseout="this.style.background='#000'; this.style.transform='none'">
-            맛집 등록
+            맛집 검색 및 등록하기
           </button>
         </div>
         <div id="map-container">


### PR DESCRIPTION
## 📌 과제 설명
마이페이지 내 개인 맛집 지도 조회 기능을 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용 

- 마이페이지 내 저장된 맛집 내역을 맵 형식과 리스트형식으로 조회하도록 구현했습니다.
- 맵 : 저장된 맛집을 공개 여부에 따라 다른 색상의 핀으로 조회
- 리스트 : 저장된 맛집의 공개여부 및 삭제 가능
- 각 핀 또는 리스트 내 상호명을 클릭할 경우 해당 위치로 맵의 중심이 이동되며, 저장된 상호명이 오버레이 되도록 구현했습니다.