### PR TITLE
feat: 모임 조회 및 모임 관련 페이지 접근 시 activated = true 필터 적용 및 모임 비활성화(삭제) 기능 추가

### DIFF
--- a/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
@@ -12,11 +12,13 @@ import com.grepp.matnam.infra.response.ApiResponse;
 import com.grepp.matnam.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -153,6 +155,19 @@ public class TeamApiController {
         }
     }
 
+    //주최자 모임 삭제 (주최자 -> Activated = false, 실제로는 비활성화)
+    @DeleteMapping("/{teamId}/deactivate")
+    @Operation(summary = "모임 비활성화", description = "모임을 비활성화합니다.")
+    public ResponseEntity<ApiResponse> unActivatedTeamByLeader(@PathVariable Long teamId) {
+        try {
+            teamService.unActivatedTeamByLeader(teamId);
+            return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "모임이 삭제되었습니다.", null));
+        } catch (Exception e) {
+            log.error("모임 삭제 중 오류 발생: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "삭제 실패", e.getMessage()));
+        }
+    }
 
     private TeamDto convertToTeamDto(Team team) {
         TeamDto teamDto = new TeamDto();

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
@@ -18,17 +18,23 @@ import org.springframework.stereotype.Repository;
 public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositoryCustom {
 
     // 사용자 ID로 팀 조회 (주최자)
-    List<Team> findTeamsByUser_UserId(String userId);
+    List<Team> findTeamsByUser_UserIdAndActivatedTrue(String userId);
 
-    @Query("SELECT t FROM Team t JOIN t.participants p WHERE p.user.userId = :userId AND p.participantStatus = :participantStatus")
-    List<Team> findTeamsByParticipantUserIdAndParticipantStatus(@Param("userId") String userId,
-        @Param("participantStatus") ParticipantStatus participantStatus);
+    @Query("SELECT t FROM Team t JOIN t.participants p " +
+            "WHERE p.user.userId = :userId AND p.participantStatus = :participantStatus AND t.activated = true")
+    List<Team> findTeamsByParticipantUserIdAndParticipantStatusAndActivatedTrue(
+            @Param("userId") String userId,
+            @Param("participantStatus") ParticipantStatus participantStatus
+    );
 
-    @Query("SELECT t FROM Team t LEFT JOIN FETCH t.participants ORDER BY t.createdAt DESC")
-    Page<Team> findAllWithParticipants(Pageable pageable);
+    @Query("SELECT t FROM Team t LEFT JOIN FETCH t.participants WHERE t.activated = true ORDER BY t.createdAt DESC")
+    Page<Team> findAllWithParticipantsAndActivatedTrue(Pageable pageable);
 
-    @Query("SELECT t FROM Team t LEFT JOIN FETCH t.participants p LEFT JOIN FETCH p.user WHERE t.teamId = :teamId")
-    Optional<Team> findByIdWithParticipantsAndUser(@Param("teamId") Long teamId);
+    @Query("SELECT t FROM Team t LEFT JOIN FETCH t.participants p LEFT JOIN FETCH p.user " +
+            "WHERE t.teamId = :teamId AND t.activated = true")
+    Optional<Team> findByIdWithParticipantsAndUserAndActivatedTrue(@Param("teamId") Long teamId);
+
+    Optional<Team> findByTeamIdAndActivatedTrue(Long teamId);
 
     long countByCreatedAtBetween(LocalDateTime createdAtAfter, LocalDateTime createdAtBefore);
 

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -61,7 +61,7 @@ public class TeamService {
     // 참여자 추가
     @Transactional
     public void addParticipant(Long teamId, User user) {
-        Team team = teamRepository.findById(teamId)
+        Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
             .orElseThrow(() -> new IllegalArgumentException("해당 모임이 존재하지 않습니다."));
 
         if (!participantRepository.existsByUser_UserIdAndTeam_TeamId(user.getUserId(), teamId)) {

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -458,6 +458,11 @@ public class TeamService {
         return stats;
     }
 
+    //주최자 모임 삭제
+    @Transactional
+    public void unActivatedTeamByLeader(Long teamId) {
+        unActivatedById(teamId);
+    }
     // 모임 수정
 //    public TeamDto getTeamDetails(Long teamId) {
 //    }

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -132,8 +132,8 @@ public class TeamService {
     // 모임 업데이트
     @Transactional
     public void updateTeam(Long teamId, Team updatedTeam) {
-        Team team = teamRepository.findById(teamId)
-            .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+        Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
+                .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
 
         team.setTeamTitle(updatedTeam.getTeamTitle());
         team.setTeamDetails(updatedTeam.getTeamDetails());
@@ -153,8 +153,8 @@ public class TeamService {
     @Transactional
     public void changeTeamStatus(Long teamId, Status status) {
         log.info("팀 ID: {} 상태 변경 시도, 변경할 상태: {}", teamId, status); // 로그 추가
-        Team team = teamRepository.findById(teamId)
-            .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다.")); //예외처리 수정하기
+        Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
+                .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다.")); //예외처리 수정하기
         Status prevStatus = team.getStatus();
         team.setStatus(status);
 
@@ -179,8 +179,8 @@ public class TeamService {
     // 모임 취소
     @Transactional
     public void cancelTeam(Long teamId, User currentUser) {
-        Team team = teamRepository.findById(teamId)
-            .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
+        Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
+                .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
 
         if (!team.getUser().getUserId().equals(currentUser.getNickname())) {
             throw new IllegalStateException("주최자만 모임을 취소할 수 있습니다.");
@@ -198,13 +198,14 @@ public class TeamService {
     //조회 부분
     // 주최자로서의 팀 조회
     public List<Team> getTeamsByLeader(String userId) {
-        return teamRepository.findTeamsByUser_UserId(userId);
+        return teamRepository.findTeamsByUser_UserIdAndActivatedTrue(userId);
     }
 
     //참여자로서의 팀 조회 (APPROVED 상태)
     public List<Team> getTeamsByParticipant(String userId) {
-        return teamRepository.findTeamsByParticipantUserIdAndParticipantStatus(userId,
-            ParticipantStatus.APPROVED);
+        return teamRepository.findTeamsByParticipantUserIdAndParticipantStatusAndActivatedTrue(
+                userId, ParticipantStatus.APPROVED
+        );
     }
 
     // 사용자의 모든 참여 정보 조회 (PENDING, APPROVED, REJECTED)
@@ -217,6 +218,7 @@ public class TeamService {
         List<Participant> participants = getAllParticipantsForUser(userId);
         return participants.stream()
             .map(Participant::getTeam)
+                .filter(Team::isActivated)
             .distinct()
             .collect(Collectors.toList());
     }
@@ -229,8 +231,7 @@ public class TeamService {
 
     // 참여자 상세 정보 조회(참여 상태)
     public Team getTeamById(Long teamId) {
-        return teamRepository.findById(teamId)
-            .orElse(null);
+        return teamRepository.findByTeamIdAndActivatedTrue(teamId).orElse(null);
     }
 
     public Participant getParticipantById(Long participantId) {
@@ -239,20 +240,20 @@ public class TeamService {
 
     // 모임 검색 페이지
     public Page<Team> getAllTeams(Pageable pageable) {
-        return teamRepository.findAllWithParticipants(pageable);
+        return teamRepository.findAllWithParticipantsAndActivatedTrue(pageable);
     }
 
     // 모임 상세 조회
     @Transactional
     public Team getTeamByIdWithParticipants(Long teamId) {
-        return teamRepository.findByIdWithParticipantsAndUser(teamId).orElse(null);
+        return teamRepository.findByIdWithParticipantsAndUserAndActivatedTrue(teamId).orElse(null);
     }
 
     // 모임 완료 처리
     @Transactional
     public void completeTeam(Long teamId) {
-        Team team = teamRepository.findById(teamId)
-            .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
+        Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
+                .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
 
         Status prevStatus = team.getStatus();
 
@@ -301,8 +302,8 @@ public class TeamService {
 
     @Transactional
     public void updateTeamStatus(Long teamId, Status status) {
-        Team team = teamRepository.findById(teamId)
-            .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
+        Team team = teamRepository.findByTeamIdAndActivatedTrue(teamId)
+                .orElseThrow(() -> new RuntimeException("팀을 찾을 수 없습니다."));
         team.setStatus(status);
     }
 

--- a/src/main/resources/templates/team/teamEdit.html
+++ b/src/main/resources/templates/team/teamEdit.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>맛남 | 모임 수정</title>
   <style>
-    /* 기존 스타일 그대로 유지 */
     body {
       font-family: 'Noto Sans KR', sans-serif;
       margin: 0;
@@ -39,9 +38,31 @@
       margin: 2rem auto;
       padding: 0 1rem;
     }
-    h1 {
-      font-size: 1.5rem;
+    .title-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
       margin-bottom: 1.5rem;
+    }
+    .title-row h1 {
+      font-size: 1.5rem;
+      margin: 0;
+    }
+    .delete-button {
+      margin: 0;
+    }
+    .delete-button button {
+      padding: 0.4rem 1rem;
+      background-color: #dc3545;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      cursor: pointer;
+    }
+    .delete-button button:hover {
+      background-color: #c82333;
+      transition: background-color 0.2s ease;
     }
     label {
       display: block;
@@ -99,7 +120,7 @@
       background-color: #000;
       color: #fff;
     }
-    input[type=\"file\"] {
+    input[type="file"] {
       border: none;
       padding: 0;
     }
@@ -120,9 +141,13 @@
 </header>
 
 <div class="container">
-  <h1>모임 수정</h1>
+  <div class="title-row">
+    <h1>모임 수정</h1>
+    <div class="delete-button">
+      <button id="deleteButton" type="button" th:attr="data-team-id=${team.teamId}">모임 삭제</button>
+    </div>
+  </div>
   <form th:action="@{/team/edit/{teamId}(teamId=${team.teamId})}" method="post">
-
     <div class="section">
       <label>모임 제목</label>
       <input type="text" name="title" placeholder="모임 제목을 입력하세요" th:value="${team.teamTitle}" required>
@@ -132,7 +157,6 @@
 
       <label>날짜</label>
       <input type="date" name="date" th:value="${#temporals.format(team.teamDate, 'yyyy-MM-dd')}" required>
-
 
       <label>시간</label>
       <input type="time" name="time" th:value="${#temporals.format(team.teamDate, 'HH:mm')}" required>
@@ -150,16 +174,10 @@
 
       <label>최대 인원</label>
       <select th:field="*{team.maxPeople}" required>
-        <option value="1" th:selected="${team.maxPeople == 1}">1명</option>
-        <option value="2" th:selected="${team.maxPeople == 2}">2명</option>
-        <option value="3" th:selected="${team.maxPeople == 3}">3명</option>
-        <option value="4" th:selected="${team.maxPeople == 4}">4명</option>
-        <option value="5" th:selected="${team.maxPeople == 5}">5명</option>
-        <option value="6" th:selected="${team.maxPeople == 6}">6명</option>
-        <option value="7" th:selected="${team.maxPeople == 7}">7명</option>
-        <option value="8" th:selected="${team.maxPeople == 8}">8명</option>
-        <option value="9" th:selected="${team.maxPeople == 9}">9명</option>
-        <option value="10" th:selected="${team.maxPeople == 10}">10명</option>
+        <option th:each="i : ${#numbers.sequence(1,10)}"
+                th:value="${i}" th:text="${i + '명'}"
+                th:selected="${team.maxPeople == i}">
+        </option>
       </select>
     </div>
 
@@ -190,5 +208,36 @@
     </div>
   </form>
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const deleteBtn = document.getElementById('deleteButton');
+    if (deleteBtn) {
+      const teamId = deleteBtn.getAttribute('data-team-id');
+      deleteBtn.addEventListener('click', function () {
+        if (!confirm("정말로 이 모임을 삭제하시겠습니까?")) return;
+
+        fetch(`${location.origin}/api/team/${teamId}/deactivate`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+                .then(res => {
+                  if (!res.ok) {
+                    return res.json().then(err => { throw new Error(err.message || '삭제 실패'); });
+                  }
+                  return res.json();
+                })
+                .then(data => {
+                  alert(data.message || "삭제되었습니다.");
+                  window.location.href = "/user/mypage";
+                })
+                .catch(err => {
+                  alert(err.message || "삭제 중 오류가 발생했습니다.");
+                });
+      });
+    }
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## 📌 과제 설명
모임 조회 및 모임 관련 페이지 접근 시 activated = true 필터 적용 및 모임 비활성화(삭제) 기능 추가

## 👩‍💻 요구 사항과 구현 내용
teamEdit 페이지
- 모임 삭제 버튼 추가
- 클릭 시 해당 모임의 activated = false 처리

TeamService / TeamRepository
- 비활성화된 모임은 마이페이지, 검색, 상세 등에서 더 이상 조회할 수 없도록 필터 적용했습니다.
- 기존 findById -> findByTeamIdAndActivatedTrue 로 안전성 부여했습니다.
