### PR TITLE
feat: 알림 대상 추가

### DIFF
--- a/src/main/java/com/grepp/matnam/app/controller/api/admin/payload/ParticipantResponse.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/admin/payload/ParticipantResponse.java
@@ -19,7 +19,7 @@ public class ParticipantResponse {
     private String email;
     private Role role;
     private ParticipantStatus participantStatus;
-    private String createDate;
+    private String createdDate;
 
     public ParticipantResponse(Participant p) {
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -30,7 +30,7 @@ public class ParticipantResponse {
         this.email = p.getUser().getEmail();
         this.role = p.getRole();
         this.participantStatus = p.getParticipantStatus();
-        this.createDate = p.getCreatedAt().format(dateFormatter);
+        this.createdDate = p.getCreatedAt().format(dateFormatter);
     }
 
 }

--- a/src/main/java/com/grepp/matnam/app/facade/NotificationSender.java
+++ b/src/main/java/com/grepp/matnam/app/facade/NotificationSender.java
@@ -34,8 +34,10 @@ public class NotificationSender {
     }
 
     public void resendNotificationToUser(String userId, Notice notice) {
+        Notification notification = notificationService.createNotification(userId, notice.getType(), notice.getMessage(), notice.getLink());
+
         // 알림 SSE 전송
-        sseService.sendNotificationToUser(userId, "newMessage", notice);
+        sseService.sendNotificationToUser(userId, "newMessage", notification);
 
         // 읽지 않은 알림 개수 전송
         long unreadCount = notificationRepository.countByUserIdAndIsReadFalseAndActivatedTrue(userId);

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
@@ -63,6 +63,6 @@ public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositor
 
     @Query("SELECT new com.grepp.matnam.app.model.team.dto.ParticipantWithUserIdDto(p.participantId, u.userId) " +
         "FROM Participant p JOIN p.user u " +
-        "WHERE p.team.teamId = :teamId AND p.team.activated = true AND p.participantStatus = 'APPROVED'")
+        "WHERE p.team.teamId = :teamId AND p.participantStatus = 'APPROVED'")
     List<ParticipantWithUserIdDto> findAllDtoByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
@@ -63,6 +63,6 @@ public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositor
 
     @Query("SELECT new com.grepp.matnam.app.model.team.dto.ParticipantWithUserIdDto(p.participantId, u.userId) " +
         "FROM Participant p JOIN p.user u " +
-        "WHERE p.team.teamId = :teamId AND p.team.activated = true")
+        "WHERE p.team.teamId = :teamId AND p.team.activated = true AND p.participantStatus = 'APPROVED'")
     List<ParticipantWithUserIdDto> findAllDtoByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamReviewService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamReviewService.java
@@ -1,5 +1,7 @@
 package com.grepp.matnam.app.model.team;
 
+import com.grepp.matnam.app.facade.NotificationSender;
+import com.grepp.matnam.app.model.notification.code.NotificationType;
 import com.grepp.matnam.app.model.team.code.Status;
 import com.grepp.matnam.app.model.team.entity.Participant;
 import com.grepp.matnam.app.model.team.entity.Team;
@@ -22,6 +24,7 @@ public class TeamReviewService {
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
     private final ParticipantRepository participantRepository;
+    private final NotificationSender notificationSender;
 
     public TeamReview createReview(Long teamId, String reviewerId, String revieweeId, Double rating) {
         Team team = teamRepository.findById(teamId)
@@ -60,6 +63,8 @@ public class TeamReviewService {
         TeamReview savedReview = teamReviewRepository.save(review);
 
         updateTemperatureByReview(revieweeId, rating);
+
+        notificationSender.sendNotificationToUser(revieweeId, NotificationType.REVIEW_RECEIVED, "[" + team.getTeamTitle() + "] 모임의 리뷰를 받았습니다!", "/team/" + team.getTeamId() + "/reviews");
 
         return savedReview;
     }

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -182,6 +182,13 @@ public class TeamService {
         unActivatedById(teamId);
 
         teamRepository.save(team);
+
+        List<Participant> participants = team.getParticipants();
+        for (Participant participant : participants) {
+            if (participant.getParticipantStatus() == ParticipantStatus.APPROVED) {
+                notificationSender.sendNotificationToUser(participant.getUser().getUserId(), NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 취소되었습니다.", null);
+            }
+        }
     }
 
     //조회 부분

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -255,6 +255,13 @@ public class TeamService {
             increaseTemperatureForCompletedTeam(team);
         }
         log.info("팀 상태 변경 완료: {}", team.getStatus());
+        List<Participant> participants = team.getParticipants();
+        for (Participant participant : participants) {
+            if (participant.getParticipantStatus() == ParticipantStatus.APPROVED) {
+                notificationSender.sendNotificationToUser(participant.getUser().getUserId(), NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 완료되었습니다!", null);
+                notificationSender.sendNotificationToUser(participant.getUser().getUserId(), NotificationType.REVIEW_REQUEST, "[" + team.getTeamTitle() + "] 모임의 리뷰를 작성해주세요!", "/team/" + team.getTeamId() + "/reviews");
+            }
+        }
     }
 
     private void increaseTemperatureForCompletedTeam(Team team) {

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -127,6 +127,8 @@ public class TeamService {
             team.setStatus(Status.FULL);
         }
 
+        notificationSender.sendNotificationToUser(participant.getUser().getUserId(), NotificationType.PARTICIPANT_STATUS, "[" + team.getTeamTitle() + "] 모임에 승인되었습니다!", "/team/detail/" + team.getTeamId());
+
         teamRepository.save(team);
     }
 

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -564,5 +564,12 @@ public class TeamService {
         unActivatedById(teamId);
 
         teamRepository.save(team);
+
+        List<Participant> participants = team.getParticipants();
+        for (Participant participant : participants) {
+            if (participant.getParticipantStatus() == ParticipantStatus.APPROVED) {
+                notificationSender.sendNotificationToUser(participant.getUser().getUserId(), NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임이 삭제되었습니다.", null);
+            }
+        }
     }
 }

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -144,6 +144,8 @@ public class TeamService {
         } else {
             throw new IllegalStateException("대기 중인 참여자만 거절 가능합니다.");
         }
+        Team team = participant.getTeam();
+        notificationSender.sendNotificationToUser(participant.getUser().getUserId(), NotificationType.PARTICIPANT_STATUS, "[" + team.getTeamTitle() + "] 모임에 거절되었습니다.", "/team/detail/" + team.getTeamId());
     }
 
 

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -296,7 +296,7 @@ public class TeamService {
 
         List<ParticipantWithUserIdDto> participants = teamRepository.findAllDtoByTeamId(teamId);
         for (ParticipantWithUserIdDto dto : participants) {
-            notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임의 상태가 ["+ team.getStatus().getKoreanName() + "](으)로 변경되었습니다.", "");
+            notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임의 상태가 ["+ team.getStatus().getKoreanName() + "](으)로 변경되었습니다.", "/team/page/" + teamId);
         }
 
     }

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -314,7 +314,7 @@ public class TeamService {
 
         List<ParticipantWithUserIdDto> participants = teamRepository.findAllDtoByTeamId(teamId);
         for (ParticipantWithUserIdDto dto : participants) {
-            notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS, "[" + team.getTeamTitle() + "] 모임의 상태가 ["+ team.getStatus().getKoreanName() + "](으)로 변경되었습니다.", "/team/page/" + teamId);
+            notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS, "관리자에 의해 [" + team.getTeamTitle() + "] 모임의 상태가 ["+ team.getStatus().getKoreanName() + "](으)로 변경되었습니다.", "/team/page/" + teamId);
         }
 
     }
@@ -325,6 +325,10 @@ public class TeamService {
             .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         log.info("team {}", team);
         team.unActivated();
+        List<ParticipantWithUserIdDto> participants = teamRepository.findAllDtoByTeamId(teamId);
+        for (ParticipantWithUserIdDto dto : participants) {
+            notificationSender.sendNotificationToUser(dto.getUserId(), NotificationType.TEAM_STATUS, "관리자에 의해  [" + team.getTeamTitle() + "] 모임이 삭제되었습니다.", null);
+        }
     }
 
     public NewTeamResponse getNewTeamStats() {

--- a/src/main/java/com/grepp/matnam/app/model/user/ReportService.java
+++ b/src/main/java/com/grepp/matnam/app/model/user/ReportService.java
@@ -3,7 +3,9 @@ package com.grepp.matnam.app.model.user;
 import com.grepp.matnam.app.controller.api.admin.payload.ReportChatResponse;
 import com.grepp.matnam.app.controller.api.admin.payload.ReportTeamResponse;
 import com.grepp.matnam.app.controller.api.user.payload.ReportRequest;
+import com.grepp.matnam.app.facade.NotificationSender;
 import com.grepp.matnam.app.model.chat.repository.ChatRepository;
+import com.grepp.matnam.app.model.notification.code.NotificationType;
 import com.grepp.matnam.app.model.team.TeamRepository;
 import com.grepp.matnam.app.model.user.dto.ReportDto;
 import com.grepp.matnam.app.model.user.entity.Report;
@@ -26,6 +28,7 @@ public class ReportService {
     private final UserService userService;
     private final TeamRepository teamRepository;
     private final ChatRepository chatRepository;
+    private final NotificationSender notificationSender;
 
     public Page<ReportDto> findByFilter(Boolean status, String keyword, Pageable pageable) {
         if (status != null && StringUtils.hasText(keyword)) {
@@ -63,6 +66,7 @@ public class ReportService {
         report.setReportType(reportRequest.getReportType());
         report.setChatId(reportRequest.getChatId());
         report.setTeamId(reportRequest.getTeamId());
+        notificationSender.sendNotificationToUser("admin", NotificationType.REPORT, user.getUserId() + "님의 신고가 접수되었습니다.", "/admin/user/report");
 
         reportRepository.save(report);
     }

--- a/src/main/resources/static/css/admin-styles.css
+++ b/src/main/resources/static/css/admin-styles.css
@@ -38,7 +38,7 @@ body {
 
 a {
     text-decoration: none;
-    color: black;
+    color: var(--dark-color);
 }
 
 ul {

--- a/src/main/resources/static/css/admin-styles.css
+++ b/src/main/resources/static/css/admin-styles.css
@@ -38,7 +38,7 @@ body {
 
 a {
     text-decoration: none;
-    color: var(--primary-color);
+    color: black;
 }
 
 ul {

--- a/src/main/resources/static/css/notification.css
+++ b/src/main/resources/static/css/notification.css
@@ -23,6 +23,11 @@
   --font-family: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
+a {
+  text-decoration: none;
+  color: black;
+}
+
 .notification i {
   font-size: 1.25rem;
   color: var(--gray-dark);

--- a/src/main/resources/static/css/notification.css
+++ b/src/main/resources/static/css/notification.css
@@ -25,7 +25,7 @@
 
 a {
   text-decoration: none;
-  color: black;
+  color: var(--dark-color);
 }
 
 .notification i {


### PR DESCRIPTION
## 📌 과제 설명
지난 번의 알림 대상에서 사용자 행위 알림과 관리자 행위 알림 추가
## 👩‍💻 요구 사항과 구현 내용
* 추가 알림 대상
  * 관리자
    * 모임 상태 변경 시 (모집 중, 모집 마감, 완료, 취소) (해당 모임의 모든 참가자들에게)
    * 모임 삭제 시 (해당 모임의 모든 참가자들에게)
  * 사용자
    * 리더일 경우 새로운 참가자 상태(승인, 거절)를 변경했을 때 (상태를 변경 당한 참가자들에게) 
    * 모임이 완료되었을 때, 리뷰 작성하라는 알림 (완료된 모임의 참가자들에게) 
    * 리뷰를 작성했을 때 (리뷰 받은 사용자에게 알림)
    * 주최자가 모임 상태를 변경했을 때 (모임 참가자들에게)
    * 사용자가 신고를 했을 때 (관리자에게)
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
