### PR TITLE
fix: 모임 취소 후 완료 수정

### DIFF
--- a/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
@@ -1,8 +1,6 @@
 package com.grepp.matnam.app.controller.api.team;
 
-import com.grepp.matnam.app.controller.api.team.payload.TeamRequest;
 import com.grepp.matnam.app.model.team.TeamService;
-import com.grepp.matnam.app.model.team.code.ParticipantStatus;
 import com.grepp.matnam.app.model.team.code.Status;
 import com.grepp.matnam.app.model.team.dto.TeamDto;
 import com.grepp.matnam.app.model.team.entity.Team;
@@ -11,21 +9,15 @@ import com.grepp.matnam.app.model.user.entity.User;
 import com.grepp.matnam.infra.response.ApiResponse;
 import com.grepp.matnam.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,10 +34,17 @@ public class TeamApiController {
 
     // 모임 상태 변경 - 모임 완료
     @PutMapping("/{teamId}/complete")
-    public ResponseEntity<String> completeTeam(@PathVariable Long teamId, @RequestParam Status status) {
+    public ResponseEntity<String> completeTeam(@PathVariable Long teamId,
+        @RequestParam Status status) {
 
         String UserId = SecurityContextHolder.getContext().getAuthentication().getName();
         try {
+            long approvedCount = teamService.getParticipantCountExcludingHost(teamId);
+            if (approvedCount < 1) {
+                return ResponseEntity
+                    .badRequest()
+                    .body("참가자가 없어 모임을 완료할 수 없습니다.");
+            }
 
             teamService.completeTeam(teamId, status, UserId);
             return ResponseEntity.ok("모임이 성공적으로 완료 처리되었습니다.");
@@ -89,7 +88,8 @@ public class TeamApiController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "서버 오류 발생", e.getMessage()));
+                .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "서버 오류 발생",
+                    e.getMessage()));
         }
     }
 
@@ -97,7 +97,8 @@ public class TeamApiController {
     // 승인 처리
     @PostMapping("/{teamId}/approve/{participantId}")
     @Operation(summary = "참여자 승인", description = "모임에 참여한 참가자를 승인합니다.")
-    public ResponseEntity<ApiResponse> approveParticipant(@PathVariable Long teamId, @PathVariable Long participantId) {
+    public ResponseEntity<ApiResponse> approveParticipant(@PathVariable Long teamId,
+        @PathVariable Long participantId) {
 
         String UserId = SecurityContextHolder.getContext().getAuthentication().getName();
         try {
@@ -105,39 +106,46 @@ public class TeamApiController {
             Team team = teamService.getTeamById(teamId);
             TeamDto teamDto = convertToTeamDto(team);
 
-            return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "참여자가 승인되었습니다.", teamDto));
+            return ResponseEntity.ok(
+                new ApiResponse(ResponseCode.OK.code(), "참여자가 승인되었습니다.", teamDto));
 
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest()
-                .body(new ApiResponse(ResponseCode.BAD_REQUEST.code(), "참여자 승인 실패", e.getMessage()));
+                .body(
+                    new ApiResponse(ResponseCode.BAD_REQUEST.code(), "참여자 승인 실패", e.getMessage()));
 
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "서버 오류 발생", e.getMessage()));
+                .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "서버 오류 발생",
+                    e.getMessage()));
         }
     }
 
     // 거절 처리
     @PostMapping("/{teamId}/reject/{participantId}")
     @Operation(summary = "참여자 거절", description = "모임에 참여한 참가자를 거절합니다.")
-    public ResponseEntity<ApiResponse> rejectParticipant(@PathVariable Long teamId, @PathVariable Long participantId) {
+    public ResponseEntity<ApiResponse> rejectParticipant(@PathVariable Long teamId,
+        @PathVariable Long participantId) {
 
         String UserId = SecurityContextHolder.getContext().getAuthentication().getName();
         try {
             teamService.rejectParticipant(participantId, UserId);
             Team team = teamService.getTeamById(teamId);
             TeamDto teamDto = convertToTeamDto(team);
-            return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "참여자가 거절되었습니다.", teamDto));
+            return ResponseEntity.ok(
+                new ApiResponse(ResponseCode.OK.code(), "참여자가 거절되었습니다.", teamDto));
 
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest()
-                .body(new ApiResponse(ResponseCode.BAD_REQUEST.code(), "참여자 거절 실패", e.getMessage()));
+                .body(
+                    new ApiResponse(ResponseCode.BAD_REQUEST.code(), "참여자 거절 실패", e.getMessage()));
 
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "서버 오류 발생", e.getMessage()));
+                .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "서버 오류 발생",
+                    e.getMessage()));
         }
     }
 
@@ -153,7 +161,8 @@ public class TeamApiController {
         } catch (Exception e) {
             log.error("모임 삭제 중 오류 발생: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "삭제 실패", e.getMessage()));
+                .body(new ApiResponse(ResponseCode.INTERNAL_SERVER_ERROR.code(), "삭제 실패",
+                    e.getMessage()));
         }
     }
 

--- a/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/team/TeamApiController.java
@@ -73,11 +73,11 @@ public class TeamApiController {
     // 참여 신청
     @PostMapping("/{teamId}/apply/{userId}")
     @Operation(summary = "모임 참여 신청", description = "사용자가 모임에 참여 신청을 합니다.")
-    public ResponseEntity<ApiResponse> applyToJoinTeam(@PathVariable Long teamId, @PathVariable String userId) {
+    public ResponseEntity<ApiResponse> applyToJoinTeam(@PathVariable Long teamId) {
 
-        String loggedInUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+        String UserId = SecurityContextHolder.getContext().getAuthentication().getName();
         try {
-            User user = userService.getUserById(loggedInUserId);
+            User user = userService.getUserById(UserId);
             teamService.addParticipant(teamId, user);
 
             return ResponseEntity.ok(new ApiResponse(ResponseCode.OK.code(), "참여 신청 성공", null));

--- a/src/main/java/com/grepp/matnam/app/model/team/ParticipantRepository.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/ParticipantRepository.java
@@ -34,4 +34,16 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
     // 특정 팀에 속하고 상태가 승인 상태인 사용자 조회
     List<Participant> findByTeam_TeamIdAndParticipantStatus(Long teamId, ParticipantStatus participantStatus);
 
+    @Query("""
+       SELECT COUNT(p)
+         FROM Participant p
+        WHERE p.team.teamId      = :teamId
+          AND p.participantStatus = :status
+          AND p.user.userId       <> p.team.user.userId
+    """)
+    long countApprovedExcludingHost(
+        @Param("teamId") Long teamId,
+        @Param("status") ParticipantStatus status
+    );
+
 }

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
@@ -28,7 +28,7 @@ public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositor
             @Param("participantStatus") ParticipantStatus participantStatus
     );
 
-    @Query("SELECT t FROM Team t LEFT JOIN FETCH t.participants WHERE t.activated = true AND t.status != 'COMPLETED' ORDER BY t.createdAt DESC")
+    @Query("SELECT t FROM Team t LEFT JOIN FETCH t.participants WHERE t.activated = true AND t.status != 'COMPLETED' AND t.status != 'CANCELED' ORDER BY t.createdAt DESC")
     Page<Team> findAllWithParticipantsAndActivatedTrue(Pageable pageable);
 
     @Query("SELECT t FROM Team t LEFT JOIN FETCH t.participants p LEFT JOIN FETCH p.user " +

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Repository;
 public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositoryCustom {
 
     // 사용자 ID로 팀 조회 (주최자)
-    @Query("SELECT t FROM Team t WHERE EXISTS (SELECT p FROM Participant p "
-        + "WHERE p.team = t AND p.user.userId = :userId AND p.participantStatus = :status) AND t.activated = true")
     List<Team> findTeamsByUser_UserIdAndActivatedTrue(String userId);
 
     @Query("SELECT t FROM Team t JOIN t.participants p " +

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamRepository.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Repository;
 public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositoryCustom {
 
     // 사용자 ID로 팀 조회 (주최자)
+    @Query("SELECT t FROM Team t WHERE EXISTS (SELECT p FROM Participant p "
+        + "WHERE p.team = t AND p.user.userId = :userId AND p.participantStatus = :status) AND t.activated = true")
     List<Team> findTeamsByUser_UserIdAndActivatedTrue(String userId);
 
     @Query("SELECT t FROM Team t JOIN t.participants p " +

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -198,7 +198,6 @@ public class TeamService {
             throw new IllegalStateException("모임완료 상태에서는 취소할 수 없습니다.");
         }
         team.setStatus(Status.CANCELED);
-//        unActivatedById(teamId);
 
         teamRepository.save(team);
 

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -198,7 +198,7 @@ public class TeamService {
             throw new IllegalStateException("모임완료 상태에서는 취소할 수 없습니다.");
         }
         team.setStatus(Status.CANCELED);
-        unActivatedById(teamId);
+//        unActivatedById(teamId);
 
         teamRepository.save(team);
 

--- a/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
+++ b/src/main/java/com/grepp/matnam/app/model/team/TeamService.java
@@ -249,7 +249,7 @@ public class TeamService {
         return teamRepository.findAllWithParticipantsAndActivatedTrue(pageable);
     }
 
-    // 모임 상세 조회
+    // 모임 상세 조회, 팀 페이지 조회
     @Transactional
     public Team getTeamByIdWithParticipants(Long teamId) {
         return teamRepository.findByIdWithParticipantsAndUserAndActivatedTrue(teamId).orElse(null);
@@ -313,6 +313,11 @@ public class TeamService {
                 userRepository.save(user);
             }
         }
+    }
+
+    // 승인된 상태의 참여자 수
+    public long getParticipantCountExcludingHost(Long teamId) {
+        return participantRepository.countApprovedExcludingHost(teamId, ParticipantStatus.APPROVED);
     }
 
 //    public List<Team> findAll() {

--- a/src/main/resources/templates/team/teamPage.html
+++ b/src/main/resources/templates/team/teamPage.html
@@ -246,6 +246,25 @@
       background-color: #f44336;
     }
 
+    .complete-button{
+      background-color: #28a745;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 5px;
+      cursor: pointer;
+      font-size: 1rem;
+    }
+    .complete-button:hover{
+      background-color: #3da354;
+    }
+
+    .complete-button:disabled {
+      background-color: #9e3c3c;
+      color: #686767;
+      cursor: not-allowed;
+    }
+
     .card-wrapper {
       display: flex;
       flex-wrap: nowrap;
@@ -332,19 +351,16 @@
   <div class="section">
     <div style="display: flex; justify-content: space-between; align-items: center;">
     <h2>방장 정보</h2>
-<!--    <div style="text-align: right;">-->
-      <form th:if="${isLeader != null && isLeader && team.status != null && #strings.toString(team.status) != 'COMPLETED'}"
+      <form th:if="${isLeader != null && isLeader && #strings.toString(team.status) != null && #strings.toString(team.status) != 'COMPLETED'}"
             th:action="@{/api/team/{teamId}/complete(teamId=${team.teamId})}"
             method="post" style="display: inline;">
         <button type="submit" class="complete-button"
                 th:data-team-id="${team.teamId}"
-                th:disabled="${team.status != null && #strings.toString(team.status) == 'COMPLETED'}"
-                th:text="${team.status != null && #strings.toString(team.status) == 'COMPLETED' ? '모임 완료된 상태' : '모임 완료하기'}"
-                style="background-color: #28a745; color: white; border: none; padding: 10px 20px; border-radius: 5px; cursor: pointer; font-size: 1rem;">
+                th:disabled="${#strings.toString(team.status) != null && #strings.toString(team.status) == 'COMPLETED'}"
+                th:text="${#strings.toString(team.status) != null && #strings.toString(team.status) == 'COMPLETED' ? '모임 완료된 상태' : '모임 완료하기'}">
           모임 완료하기
         </button>
       </form>
-
       <div th:if="${team.status != null && #strings.toString(team.status) == 'COMPLETED'}">
         <button type="button" class="btn complete-button" disabled
                 style="background-color: #e6e4e4; color: #606061; border: none; padding: 10px 20px; border-radius: 5px; font-size: 1rem;">
@@ -352,6 +368,7 @@
         </button>
       </div>
     </div>
+
     <div class="participant-list">
       <div class="participant" th:if="${leader}">
         <div class="participant-info">
@@ -692,9 +709,9 @@
         error: function(xhr, status, error) {
           var errorMessage = "모임 완료에 실패했습니다.";
           if (xhr.responseJSON && xhr.responseJSON.message) {
-            errorMessage = xhr.responseJSON.message; // 서버에서 보낸 오류 메시지 사용
+            errorMessage = xhr.responseJSON.message;
           } else if (xhr.responseText) {
-            errorMessage = xhr.responseText; // 서버에서 단순 텍스트 오류 응답을 받은 경우
+            errorMessage = xhr.responseText;
           }
           $('#notificationMessage').text(errorMessage);
           $('#notificationArea').fadeIn();

--- a/src/main/resources/templates/team/teamPage.html
+++ b/src/main/resources/templates/team/teamPage.html
@@ -351,7 +351,7 @@
   <div class="section">
     <div style="display: flex; justify-content: space-between; align-items: center;">
     <h2>방장 정보</h2>
-      <form th:if="${isLeader != null && isLeader && #strings.toString(team.status) != null && #strings.toString(team.status) != 'COMPLETED'}"
+      <form th:if="${isLeader != null && isLeader && #strings.toString(team.status) != null && #strings.toString(team.status) != 'COMPLETED' && #strings.toString(team.status) != 'CANCELED'}"
             th:action="@{/api/team/{teamId}/complete(teamId=${team.teamId})}"
             method="post" style="display: inline;">
         <button type="submit" class="complete-button"
@@ -365,6 +365,12 @@
         <button type="button" class="btn complete-button" disabled
                 style="background-color: #e6e4e4; color: #606061; border: none; padding: 10px 20px; border-radius: 5px; font-size: 1rem;">
           모임 완료된 상태
+        </button>
+      </div>
+      <div th:if="${team.status != null && #strings.toString(team.status) == 'CANCELED'}">
+        <button type="button" class="btn complete-button" disabled
+                style="background-color: #e6e4e4; color: #606061; border: none; padding: 10px 20px; border-radius: 5px; font-size: 1rem;">
+          취소된 모임입니다
         </button>
       </div>
     </div>

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -50,7 +50,6 @@
       padding: 0.5rem 1rem;
       border: none;
       border-radius: 4px;
-      cursor: pointer;
       font-weight: 500;
     }
 
@@ -618,13 +617,16 @@
           <p>아직 참여하거나 주최한 모임이 없습니다.</p>
           <p>모임을 만들거나 다른 사용자의 모임에 참여해보세요!</p>
         </div>
+
         <div th:each="team : ${hostingTeams}" class="meeting-item">
           <h4>
             <span th:text="${team.teamTitle}">모임 제목</span>
-            <span class="status-badge active">주최중</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'RECRUITING'}">모집중</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'FULL'}">모집완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'COMPLETED'}">모임완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'CANCELED'}">모임취소</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
-          </p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
 
@@ -632,32 +634,38 @@
           <a th:href="@{'/team/page/' + ${team.teamId}}">팀페이지</a><br>
           <hr>
 
-          <!-- 모임 수정 버튼 -->
           <button th:if="${team.user.userId == user.userId}" class="btn-primary"
                   th:onclick="'location.href=\'/team/edit/' + ${team.teamId} + '\''">
             모임 수정
           </button>
 
-          <!-- 모임 취소 버튼-->
-          <div th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}">
-            <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
-                  method="post" style="display: inline;" class="cancel-form"
-                  th:data-team-id=${team.teamId}>
-              <button type="submit" class="btn-primary cancel-button">모임 취소</button>
-            </form>
-          </div>
-          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
-            <button class="btn-secondary" disabled>모임 취소 완료</button>
+          <div th:if="${team.user.userId == user.userId}">
+            <div th:if="${#strings.toString(team.status) != 'CANCELED' and #strings.toString(team.status) != 'COMPLETED'}">
+              <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
+                    method="post" style="display: inline;" class="cancel-form"
+                    th:data-team-id=${team.teamId}>
+                <button type="submit" class="btn-primary cancel-button">모임 취소</button>
+              </form>
+            </div>
+            <div th:if="${#strings.toString(team.status) == 'CANCELED'}" style="display: inline;">
+              <button class="btn-secondary" disabled>모임 취소 완료</button>
+            </div>
+            <div th:if="${#strings.toString(team.status) == 'COMPLETED'}" style="display: inline;">
+              <button class="btn-success" disabled>모임 완료됨</button>
+            </div>
           </div>
         </div>
 
         <div th:each="team : ${participatingTeams}" class="meeting-item">
           <h4>
             <span th:text="${team.teamTitle}">모임 제목</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'RECRUITING'}">모집중</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'FULL'}">모집완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'COMPLETED'}">모임완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'CANCELED'}">모임취소</span>
             <span class="status-badge">참여중</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
-          </p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
           <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
@@ -674,37 +682,42 @@
         <div th:each="team : ${hostingTeams}" class="meeting-item">
           <h4>
             <span th:text="${team.teamTitle}">모임 제목</span>
-            <span class="status-badge active">주최중</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'RECRUITING'}">모집중</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'FULL'}">모집완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'COMPLETED'}">모임완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'CANCELED'}">모임취소</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
-          </p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
 
           <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
           <a th:href="@{'/team/page/' + ${team.teamId}}">팀페이지</a><br>
-
           <hr>
 
-          <!-- 모임 수정 버튼 -->
           <button th:if="${team.user.userId == user.userId}" class="btn-primary"
                   th:onclick="'location.href=\'/team/edit/' + ${team.teamId} + '\''">
             모임 수정
           </button>
 
-          <!-- 모임 취소 버튼-->
-          <div th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}">
-            <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
-                  method="post" style="display: inline;" class="cancel-form"
-                  th:data-team-id=${team.teamId}>
-              <button type="submit" class="btn-primary cancel-button">모임 취소</button>
-            </form>
-          </div>
-          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
-            <button class="btn-secondary" disabled>모임 취소 완료</button>
+          <div th:if="${team.user.userId == user.userId}">
+            <div th:if="${#strings.toString(team.status) != 'CANCELED' and #strings.toString(team.status) != 'COMPLETED'}">
+              <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
+                    method="post" style="display: inline;" class="cancel-form"
+                    th:data-team-id=${team.teamId}>
+                <button type="submit" class="btn-primary cancel-button">모임 취소</button>
+              </form>
+            </div>
+            <div th:if="${#strings.toString(team.status) == 'CANCELED'}" style="display: inline;">
+              <button class="btn-secondary" disabled>모임 취소 완료</button>
+            </div>
+            <div th:if="${#strings.toString(team.status) == 'COMPLETED'}" style="display: inline;">
+              <button class="btn-success" disabled>모임 완료됨</button>
+            </div>
           </div>
         </div>
       </div>
+
       <div id="participating-meetings" class="meetings-section" style="display: none;">
         <h3>참여 중인 모임</h3>
         <div th:if="${#lists.isEmpty(participatingTeams)}" class="empty-state">
@@ -714,10 +727,13 @@
         <div th:each="team : ${participatingTeams}" class="meeting-item">
           <h4>
             <span th:text="${team.teamTitle}">모임 제목</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'RECRUITING'}">모집중</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'FULL'}">모집완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'COMPLETED'}">모임완료</span>
+            <span class="status-badge" th:if="${#strings.toString(team.status) == 'CANCELED'}">모임취소</span>
             <span class="status-badge">참여중</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
-          </p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
           <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
@@ -883,19 +899,20 @@
           })
           .then(data => {
             alert(data.message || "모임이 취소되었습니다.");
+            location.reload();
 
-            const cancelButton = form.querySelector('.cancel-button');
-            if (cancelButton) {
-              cancelButton.style.display = 'none';
-            }
-
-            const completedButton = document.createElement('button');
-            completedButton.className = 'btn-secondary';
-            completedButton.disabled = true;
-            completedButton.textContent = '모임 취소 완료';
-            completedButton.style.pointerEvents = 'none';
-
-            form.parentNode.appendChild(completedButton);
+          //   const cancelButton = form.querySelector('.cancel-button');
+          //   if (cancelButton) {
+          //     cancelButton.style.display = 'none';
+          //   }
+          //
+          //   const completedButton = document.createElement('button');
+          //   completedButton.className = 'btn-secondary';
+          //   completedButton.disabled = true;
+          //   completedButton.textContent = '모임 취소 완료';
+          //   completedButton.style.pointerEvents = 'none';
+          //
+          //   form.parentNode.appendChild(completedButton);
           })
           .catch(err => {
             console.error("모임 취소 오류:", err);

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -33,8 +33,8 @@
     .btn-primary {
       background-color: #000;
       color: white;
+      border-color: #cccccc;
       padding: 0.5rem 1rem;
-      border: none;
       border-radius: 4px;
       cursor: pointer;
       font-weight: 500;
@@ -45,12 +45,25 @@
     }
 
     .btn-secondary {
-      background-color: #878787;
-      color: white;
       padding: 0.5rem 1rem;
-      border: none;
       border-radius: 4px;
       font-weight: 500;
+      background-color: #e8b9b9;
+      color: #755252;
+      border-color: #cccccc;
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+
+    .btn-success {
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      font-weight: 500;
+      background-color: #b9e8ba;
+      color: #4a9550;
+      border-color: #cccccc;
+      cursor: not-allowed;
+      pointer-events: none;
     }
 
     .container {
@@ -415,14 +428,14 @@
     }
 
     .cancel-btn {
-      padding: 12px 24px;
-      font-size: 16px;
+      font-size: 13px;
       background-color: #ff4d4d;
-      color: white;
+      padding: 0.5rem 1rem;
       border: none;
-      border-radius: 8px;
+      border-radius: 4px;
       cursor: pointer;
-      font-weight: bold;
+      font-weight: 500;
+      color: white;
       display: inline-flex;
       align-items: center;
       gap: 8px;
@@ -434,13 +447,20 @@
     }
 
     .cancel-btn:hover {
-      background-color: #ff3333;
-      transform: scale(1.05);
+      background-color: #b13030;
     }
 
     .cancel-btn:disabled {
       background-color: #ccc;
       cursor: not-allowed;
+    }
+
+    .btn-primary[disabled] {
+      background-color: #cccccc !important;
+      color: #666666 !important;
+      border-color: #cccccc !important;
+      cursor: not-allowed !important;
+      pointer-events: none !important;
     }
 
     .pagination-container {
@@ -635,23 +655,24 @@
           <hr>
 
           <button th:if="${team.user.userId == user.userId}" class="btn-primary"
-                  th:onclick="'location.href=\'/team/edit/' + ${team.teamId} + '\''">
+                  th:onclick="'location.href=\'/team/edit/' + ${team.teamId} + '\''"
+                  th:disabled="${#strings.toString(team.status) == 'CANCELED' or #strings.toString(team.status) == 'COMPLETED'}">
             모임 수정
           </button>
 
-          <div th:if="${team.user.userId == user.userId}">
+          <div th:if="${team.user.userId == user.userId}" >
             <div th:if="${#strings.toString(team.status) != 'CANCELED' and #strings.toString(team.status) != 'COMPLETED'}">
               <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
                     method="post" style="display: inline;" class="cancel-form"
                     th:data-team-id=${team.teamId}>
-                <button type="submit" class="btn-primary cancel-button">모임 취소</button>
+                <button type="submit" class="cancel-btn">모임 취소</button>
               </form>
             </div>
             <div th:if="${#strings.toString(team.status) == 'CANCELED'}" style="display: inline;">
               <button class="btn-secondary" disabled>모임 취소 완료</button>
             </div>
             <div th:if="${#strings.toString(team.status) == 'COMPLETED'}" style="display: inline;">
-              <button class="btn-success" disabled>모임 완료됨</button>
+              <button class="btn-success" disabled>모임 완료</button>
             </div>
           </div>
         </div>
@@ -663,7 +684,6 @@
             <span class="status-badge" th:if="${#strings.toString(team.status) == 'FULL'}">모집완료</span>
             <span class="status-badge" th:if="${#strings.toString(team.status) == 'COMPLETED'}">모임완료</span>
             <span class="status-badge" th:if="${#strings.toString(team.status) == 'CANCELED'}">모임취소</span>
-            <span class="status-badge">참여중</span>
           </h4>
           <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
@@ -696,7 +716,8 @@
           <hr>
 
           <button th:if="${team.user.userId == user.userId}" class="btn-primary"
-                  th:onclick="'location.href=\'/team/edit/' + ${team.teamId} + '\''">
+                  th:onclick="'location.href=\'/team/edit/' + ${team.teamId} + '\''"
+                  th:disabled="${#strings.toString(team.status) == 'CANCELED'}">
             모임 수정
           </button>
 
@@ -705,14 +726,14 @@
               <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
                     method="post" style="display: inline;" class="cancel-form"
                     th:data-team-id=${team.teamId}>
-                <button type="submit" class="btn-primary cancel-button">모임 취소</button>
+                <button type="submit" class="cancel-btn">모임 취소</button>
               </form>
             </div>
             <div th:if="${#strings.toString(team.status) == 'CANCELED'}" style="display: inline;">
               <button class="btn-secondary" disabled>모임 취소 완료</button>
             </div>
             <div th:if="${#strings.toString(team.status) == 'COMPLETED'}" style="display: inline;">
-              <button class="btn-success" disabled>모임 완료됨</button>
+              <button class="btn-success" disabled>모임 완료</button>
             </div>
           </div>
         </div>
@@ -731,7 +752,6 @@
             <span class="status-badge" th:if="${#strings.toString(team.status) == 'FULL'}">모집완료</span>
             <span class="status-badge" th:if="${#strings.toString(team.status) == 'COMPLETED'}">모임완료</span>
             <span class="status-badge" th:if="${#strings.toString(team.status) == 'CANCELED'}">모임취소</span>
-            <span class="status-badge">참여중</span>
           </h4>
           <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -639,24 +639,18 @@
           </button>
 
           <!-- 모임 취소 버튼-->
-          <form th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}"
-                th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
-                method="post" style="display: inline;" class="cancel-form"
-                th:data-team-id=${team.teamId}>
-            <button type="submit" class="btn-primary cancel-button">모임 취소</button>
-          </form>
-<!--          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">-->
-<!--            <button class="btn-secondary" disabled>모임 취소 완료</button>-->
-<!--          </div>-->
-
-          <!--          <div id="application-info-${team.teamId}" class="application-info" style="display: none;">-->
-          <!--            <h4>신청자 목록</h4>-->
-          <!--            &lt;!&ndash; 신청자 정보 동적으로 추가될 부분 &ndash;&gt;-->
-          <!--            <ul id="applicant-list-${team.teamId}">-->
-          <!--              &lt;!&ndash; 신청자 정보 리스트 &ndash;&gt;-->
-          <!--            </ul>-->
-          <!--          </div>-->
+          <div th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}">
+            <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
+                  method="post" style="display: inline;" class="cancel-form"
+                  th:data-team-id=${team.teamId}>
+              <button type="submit" class="btn-primary cancel-button">모임 취소</button>
+            </form>
+          </div>
+          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
+            <button class="btn-secondary" disabled>모임 취소 완료</button>
+          </div>
         </div>
+
         <div th:each="team : ${participatingTeams}" class="meeting-item">
           <h4>
             <span th:text="${team.teamTitle}">모임 제목</span>
@@ -668,8 +662,6 @@
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
           <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
           <a th:href="@{'/team/page/' + ${team.teamId}}">팀페이지</a>
-          </form>
-
         </div>
       </div>
 
@@ -701,26 +693,18 @@
           </button>
 
           <!-- 모임 취소 버튼-->
-          <form th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}"
-                th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
-                method="post" style="display: inline;" class="cancel-form"
-                th:data-team-id=${team.teamId}>
-            <button type="submit" class="btn-primary cancel-button">모임 취소</button>
-          </form>
-<!--          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">-->
-<!--            <button class="btn-secondary" disabled>모임 취소 완료</button>-->
-<!--          </div>-->
-
-          <!--          <div id="application-info-${teamId}" class="application-info" style="display: none;">-->
-          <!--            <h4>신청자 목록</h4>-->
-          <!--            &lt;!&ndash; 신청자 정보 동적으로 추가될 부분 &ndash;&gt;-->
-          <!--            <ul id="applicant-list-${teamId}">-->
-          <!--              &lt;!&ndash; 신청자 정보 리스트 &ndash;&gt;-->
-          <!--            </ul>-->
-          <!--          </div>-->
+          <div th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}">
+            <form th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
+                  method="post" style="display: inline;" class="cancel-form"
+                  th:data-team-id=${team.teamId}>
+              <button type="submit" class="btn-primary cancel-button">모임 취소</button>
+            </form>
+          </div>
+          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
+            <button class="btn-secondary" disabled>모임 취소 완료</button>
+          </div>
         </div>
       </div>
-
       <div id="participating-meetings" class="meetings-section" style="display: none;">
         <h3>참여 중인 모임</h3>
         <div th:if="${#lists.isEmpty(participatingTeams)}" class="empty-state">
@@ -738,7 +722,6 @@
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
           <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
           <a th:href="@{'/team/page/' + ${team.teamId}}">팀페이지</a>
-
         </div>
       </div>
     </div>
@@ -783,7 +766,8 @@
         <p>완료된 모임에 대해 다른 참여자들의 매너 온도를 매겨주세요!</p>
       </div>
 
-      <div th:if="${#lists.isEmpty(teamsWithoutReview) and currentPage == 0}" class="empty-state">
+      <div th:if="${#lists.isEmpty(teamsWithoutReview) and currentPage == 0}"
+           class="empty-state">
         <p>리뷰 작성이 필요한 모임이 없습니다.</p>
       </div>
 
@@ -899,19 +883,19 @@
             })
             .then(data => {
               alert(data.message || "모임이 취소되었습니다.");
-
-              const cancelButton = form.querySelector('.cancel-button');
-              if (cancelButton) {
-                cancelButton.style.display = 'none';
-              }
-              const completedButton = document.createElement('button');
-              completedButton.className = 'btn-secondary';
-              completedButton.disabled = true;
-              completedButton.textContent = '모임 취소 완료';
-              completedButton.style.pointerEvents = 'none';
-
-              // 폼의 부모 요소에 취소 완료 버튼을 추가
-              form.parentNode.appendChild(completedButton);
+              location.reload();
+              //   const cancelButton = form.querySelector('.cancel-button');
+              //   if (cancelButton) {
+              //     cancelButton.style.display = 'none';
+              //   }
+              //   const completedButton = document.createElement('button');
+              //   completedButton.className = 'btn-secondary';
+              //   completedButton.disabled = true;
+              //   completedButton.textContent = '모임 취소 완료';
+              //   completedButton.style.pointerEvents = 'none';
+              //
+              //   // 폼의 부모 요소에 취소 완료 버튼을 추가
+              //   form.parentNode.appendChild(completedButton);
             })
             .catch(err => {
               console.error("모임 취소 오류:", err);

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -851,58 +851,58 @@
     switchTab('all');
   });
 
-      // 모임 취소
-      document.addEventListener('DOMContentLoaded', function () {
-        const cancelForms = document.querySelectorAll('.cancel-form');
+    // 모임 취소
+    document.addEventListener('DOMContentLoaded', function () {
+      const cancelForms = document.querySelectorAll('.cancel-form');
 
-        cancelForms.forEach(form => {
-          form.addEventListener('submit', function (event) {
-            event.preventDefault();
+      cancelForms.forEach(form => {
+        form.addEventListener('submit', function (event) {
+          event.preventDefault();
 
-            const teamId = this.getAttribute('data-team-id');
+          const teamId = this.getAttribute('data-team-id');
 
-            if (!confirm("정말로 이 모임을 취소하시겠습니까?")) {
-              return;
+          if (!confirm("정말로 이 모임을 취소하시겠습니까?")) {
+            return;
+          }
+
+          fetch(`/api/team/${teamId}/cancel`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          })
+          .then(res => {
+            if (!res.ok) {
+              return res.json().then(err => {
+                const errorData = err.message || '모임 취소 실패';
+                alert(errorData);
+                throw new Error(errorData);
+              });
+            }
+            return res.json();
+          })
+          .then(data => {
+            alert(data.message || "모임이 취소되었습니다.");
+
+            const cancelButton = form.querySelector('.cancel-button');
+            if (cancelButton) {
+              cancelButton.style.display = 'none';
             }
 
-            fetch(`/api/team/${teamId}/cancel`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-            })
-            .then(res => {
-              if (!res.ok) {
-                return res.json().then(err => {
-                  const errorData = err.message || '모임 취소 실패';
-                  alert(errorData);
-                  throw new Error(errorData);
-                });
-              }
-              return res.json();
-            })
-            .then(data => {
-              alert(data.message || "모임이 취소되었습니다.");
-              location.reload();
-              //   const cancelButton = form.querySelector('.cancel-button');
-              //   if (cancelButton) {
-              //     cancelButton.style.display = 'none';
-              //   }
-              //   const completedButton = document.createElement('button');
-              //   completedButton.className = 'btn-secondary';
-              //   completedButton.disabled = true;
-              //   completedButton.textContent = '모임 취소 완료';
-              //   completedButton.style.pointerEvents = 'none';
-              //
-              //   // 폼의 부모 요소에 취소 완료 버튼을 추가
-              //   form.parentNode.appendChild(completedButton);
-            })
-            .catch(err => {
-              console.error("모임 취소 오류:", err);
-            });
+            const completedButton = document.createElement('button');
+            completedButton.className = 'btn-secondary';
+            completedButton.disabled = true;
+            completedButton.textContent = '모임 취소 완료';
+            completedButton.style.pointerEvents = 'none';
+
+            form.parentNode.appendChild(completedButton);
+          })
+          .catch(err => {
+            console.error("모임 취소 오류:", err);
           });
         });
       });
+    });
 
   // 모임 목록 탭 전환
   function switchTab(tabName) {

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -603,7 +603,8 @@
     <div id="meetings-container">
       <div id="all-meetings" class="meetings-section">
         <h3>전체 모임</h3>
-        <div th:if="${#lists.isEmpty(hostingTeams) and #lists.isEmpty(participatingTeams)}" class="empty-state">
+        <div th:if="${#lists.isEmpty(hostingTeams) and #lists.isEmpty(participatingTeams)}"
+             class="empty-state">
           <p>아직 참여하거나 주최한 모임이 없습니다.</p>
           <p>모임을 만들거나 다른 사용자의 모임에 참여해보세요!</p>
         </div>
@@ -612,7 +613,8 @@
             <span th:text="${team.teamTitle}">모임 제목</span>
             <span class="status-badge active">주최중</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
+          </p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
 
@@ -629,25 +631,29 @@
           <!-- 모임 취소 버튼-->
           <form th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}"
                 th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
-                method="post" style="display: inline;"
-                id="cancelForm" th:attr="data-team-id=${team.teamId}"> <button type="submit" class="btn-primary">모임 취소</button>
+                method="post" style="display: inline;" class="cancel-form"
+                th:data-team-id=${team.teamId}>
+            <button type="submit" class="btn-primary cancel-button">모임 취소</button>
           </form>
-
-
-          <div id="application-info-${team.teamId}" class="application-info" style="display: none;">
-            <h4>신청자 목록</h4>
-            <!-- 신청자 정보 동적으로 추가될 부분 -->
-            <ul id="applicant-list-${team.teamId}">
-              <!-- 신청자 정보 리스트 -->
-            </ul>
+          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
+            <button class="btn-secondary" disabled>모임 취소 완료</button>
           </div>
+
+          <!--          <div id="application-info-${team.teamId}" class="application-info" style="display: none;">-->
+          <!--            <h4>신청자 목록</h4>-->
+          <!--            &lt;!&ndash; 신청자 정보 동적으로 추가될 부분 &ndash;&gt;-->
+          <!--            <ul id="applicant-list-${team.teamId}">-->
+          <!--              &lt;!&ndash; 신청자 정보 리스트 &ndash;&gt;-->
+          <!--            </ul>-->
+          <!--          </div>-->
         </div>
         <div th:each="team : ${participatingTeams}" class="meeting-item">
           <h4>
             <span th:text="${team.teamTitle}">모임 제목</span>
             <span class="status-badge">참여중</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
+          </p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
           <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
@@ -668,7 +674,8 @@
             <span th:text="${team.teamTitle}">모임 제목</span>
             <span class="status-badge active">주최중</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
+          </p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
 
@@ -684,19 +691,23 @@
           </button>
 
           <!-- 모임 취소 버튼-->
-         <form th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}"
+          <form th:if="${team.status != 'CANCELED' and team.status != 'COMPLETED'}"
                 th:action="@{/api/team/{teamId}/cancel(teamId=${team.teamId})}"
-                method="post" style="display: inline;">
-            <button type="submit" class="btn-primary">모임 취소</button>
+                method="post" style="display: inline;" class="cancel-form"
+                th:data-team-id=${team.teamId}>
+            <button type="submit" class="btn-primary cancel-button">모임 취소</button>
           </form>
-
-          <div id="application-info-${teamId}" class="application-info" style="display: none;">
-            <h4>신청자 목록</h4>
-            <!-- 신청자 정보 동적으로 추가될 부분 -->
-            <ul id="applicant-list-${teamId}">
-              <!-- 신청자 정보 리스트 -->
-            </ul>
+          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
+            <button class="btn-secondary" disabled>모임 취소 완료</button>
           </div>
+
+          <!--          <div id="application-info-${teamId}" class="application-info" style="display: none;">-->
+          <!--            <h4>신청자 목록</h4>-->
+          <!--            &lt;!&ndash; 신청자 정보 동적으로 추가될 부분 &ndash;&gt;-->
+          <!--            <ul id="applicant-list-${teamId}">-->
+          <!--              &lt;!&ndash; 신청자 정보 리스트 &ndash;&gt;-->
+          <!--            </ul>-->
+          <!--          </div>-->
         </div>
       </div>
 
@@ -711,7 +722,8 @@
             <span th:text="${team.teamTitle}">모임 제목</span>
             <span class="status-badge">참여중</span>
           </h4>
-          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span></p>
+          <p>📅 <span th:text="${#temporals.format(team.teamDate, 'yyyy년 MM월 dd일 (E) a hh:mm')}">모임 날짜</span>
+          </p>
           <p>📍 <span th:text="${team.restaurantName}">식당 이름</span></p>
           <p>👥 참여 인원: <span th:text="${team.nowPeople + '/' + team.maxPeople}">참여 인원</span></p>
           <a th:href="@{'/team/detail/' + ${team.teamId}}">자세히 보기</a><br>
@@ -845,40 +857,60 @@
     switchTab('all');
   });
 
-  // 모임 취소
-  document.addEventListener('DOMContentLoaded', function() {
-    const cancelForm = document.getElementById('cancelForm');
-    if (cancelForm) {
-      cancelForm.addEventListener('submit', function(event) {
-        event.preventDefault();
+      // 모임 취소
+      document.addEventListener('DOMContentLoaded', function () {
+        const cancelForms = document.querySelectorAll('.cancel-form');
 
-        const teamId = cancelForm.getAttribute('data-team-id');
+        cancelForms.forEach(form => {
+          form.addEventListener('submit', function (event) {
+            event.preventDefault();
 
-        if (!confirm("정말로 이 모임을 취소하시겠습니까?")) return;
+            const teamId = this.getAttribute('data-team-id');
 
-        fetch(`/api/team/${teamId}/cancel`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        })
-        .then(res => {
-          if (!res.ok) {
-            return res.json().then(err => { throw new Error(err.message || '모임 취소 실패'); });
-          }
-          return res.json();
-        })
-        .then(data => {
-          alert(data.message || "모임이 취소되었습니다.");
-          location.reload();
-        })
-        .catch(err => {
-          alert(err.message || "모임 취소 중 오류가 발생했습니다.");
+            if (!confirm("정말로 이 모임을 취소하시겠습니까?")) {
+              return;
+            }
+
+            fetch(`/api/team/${teamId}/cancel`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            })
+            .then(res => {
+              if (!res.ok) {
+                return res.json().then(err => {
+                  const errorData = err.message || '모임 취소 실패';
+                  alert(errorData);
+                  throw new Error(errorData);
+                });
+              }
+              return res.json();
+            })
+            .then(data => {
+              alert(data.message || "모임이 취소되었습니다.");
+
+              const cancelButton = form.querySelector('.cancel-button');
+              if (cancelButton) {
+                cancelButton.textContent = '모임 취소 완료';
+                cancelButton.disabled = true;
+              }
+            })
+            .catch(err => {
+              console.error("모임 취소 오류:", err);
+            });
+          });
         });
-      });
-    }
-  });
 
+        // const teamStatus = document.querySelector('[th\\:if="${team.status == \'CANCELED\'}"]');
+        // if (teamStatus) {
+        //   const cancelButton = document.querySelector('.cancel-button');
+        //   if (cancelButton) {
+        //     cancelButton.textContent = '모임 취소 완료';
+        //     cancelButton.disabled = true;
+        //   }
+        // }
+      });
 
   // 모임 목록 탭 전환
   function switchTab(tabName) {

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -44,6 +44,16 @@
       background-color: #333;
     }
 
+    .btn-secondary {
+      background-color: #878787;
+      color: white;
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-weight: 500;
+    }
+
     .container {
       display: grid;
       grid-template-columns: 1fr 3fr;
@@ -635,9 +645,9 @@
                 th:data-team-id=${team.teamId}>
             <button type="submit" class="btn-primary cancel-button">모임 취소</button>
           </form>
-          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
-            <button class="btn-secondary" disabled>모임 취소 완료</button>
-          </div>
+<!--          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">-->
+<!--            <button class="btn-secondary" disabled>모임 취소 완료</button>-->
+<!--          </div>-->
 
           <!--          <div id="application-info-${team.teamId}" class="application-info" style="display: none;">-->
           <!--            <h4>신청자 목록</h4>-->
@@ -697,9 +707,9 @@
                 th:data-team-id=${team.teamId}>
             <button type="submit" class="btn-primary cancel-button">모임 취소</button>
           </form>
-          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">
-            <button class="btn-secondary" disabled>모임 취소 완료</button>
-          </div>
+<!--          <div th:if="${team.status == 'CANCELED'}" style="display: inline;">-->
+<!--            <button class="btn-secondary" disabled>모임 취소 완료</button>-->
+<!--          </div>-->
 
           <!--          <div id="application-info-${teamId}" class="application-info" style="display: none;">-->
           <!--            <h4>신청자 목록</h4>-->
@@ -892,24 +902,22 @@
 
               const cancelButton = form.querySelector('.cancel-button');
               if (cancelButton) {
-                cancelButton.textContent = '모임 취소 완료';
-                cancelButton.disabled = true;
+                cancelButton.style.display = 'none';
               }
+              const completedButton = document.createElement('button');
+              completedButton.className = 'btn-secondary';
+              completedButton.disabled = true;
+              completedButton.textContent = '모임 취소 완료';
+              completedButton.style.pointerEvents = 'none';
+
+              // 폼의 부모 요소에 취소 완료 버튼을 추가
+              form.parentNode.appendChild(completedButton);
             })
             .catch(err => {
               console.error("모임 취소 오류:", err);
             });
           });
         });
-
-        // const teamStatus = document.querySelector('[th\\:if="${team.status == \'CANCELED\'}"]');
-        // if (teamStatus) {
-        //   const cancelButton = document.querySelector('.cancel-button');
-        //   if (cancelButton) {
-        //     cancelButton.textContent = '모임 취소 완료';
-        //     cancelButton.disabled = true;
-        //   }
-        // }
       });
 
   // 모임 목록 탭 전환


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
1. 마이페이지
- 모집중, 모집완료, 모임완료, 모임취소 확인 할 수 있게 처리

2. 모임 취소 시
- 모임 취소 알림 나오게 수정
- 모임 취소 완료로 변경
- 모임 수정도 막기
- 모임 찾기에서 안보이게 수정
- 모임 완료 못하게 수정

3. 모임 완료 시
- 모임에 참여자가 없는 경우(신청만 된 경우 포함) 모임 완료 처리 안되게 수정

4. 모임 찾기에서 취소된 모임은 조회 안되게 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
