### PR TITLE
feat: 쿠키 값 변경 및 사용자 표시 항목 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# 2차 프로젝트 - 맛남
+# NBE5-6-2-Team06
+## 맛남
+프로그래머스 백엔드 데브코스 5기 6회차 2차 프로젝트 6팀(API-Tizer)
+
+---
+## 팀원 소개
+| <img height="150" style="width: auto;" alt="f3194686510bf918" src="https://avatars.githubusercontent.com/u/97518677?v=4" /> | <img src="https://avatars.githubusercontent.com/u/145417394?v=4" height="150" style="width: auto;"> | <img src="https://avatars.githubusercontent.com/u/147399765?v=4" height="150" style="width: auto;"> | <img alt="f3194686510bf918" src="https://avatars.githubusercontent.com/u/106153233?v=4" height="150" style="width: auto;" /> | <img height="150" style="width: auto;" alt="f3194686510bf918" src="https://avatars.githubusercontent.com/u/120391720?v=4" /> |
+|:------------------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------------:|
+|                                                                          손혜은                                                                           |                                                              김윤서                                                              |                                                              박병석                                                              |                                                                          이서준                                                                           |                                                             전정원                                                              |
+|                                                                           팀장                                                                           |                                                              팀원                                                               |                                                              팀원                                                               |                                                                           팀원                                                                           |                                                              팀원                                                              |
+|                                                         [@hesador12](https://github.com/hesador12)                                                         |                                         [@yunseoy](https://github.com/yunseoy)                                          |                                            [@Parkbyungseok](https://github.com/Parkbyungseok)                                             |                                                     [@leesojun34](https://github.com/leeseojun34)                                                      |                                           [@JeonJW24](https://github.com/JeonJW24)                                           |
+---
+
+## 1. 프로젝트 개요
+### 맛집 메이트 - 맛남
+맛집을 중심으로 사람들을 연결해주는 모임 플랫폼
+
+## 2. 주요 기능
+- 사용자 관리
+- 모임 관리
+- 맛집 관리
+- 매너온도 평가
+- 2차 추천
+- 관리자
+- 채팅
+- 알림
+
+## 3. 작업 및 역할 분담
+| 이름  | 역할                                                                                                             |
+|:---:|:---------------------------------------------------------------------------------------------------------------|
+| 손혜은 | <ul><li>팀 리딩</li><li>사용자 맛집 관리</li><li>맛집 지도 등록/수정/삭제/조회</li><li>맛집 지도 공유</li></ul>                            |
+| 김윤서 | <ul><li>모임 생성/수정/삭제/조회</li><li>모임 참여 신청</li><li>모임 상태 관리</li></ul>                                             |
+| 박병석 | <ul><li>2차 추천(LLM)</li><li>모임 참가자 취향 집계 및 분석</li><li>모임별 채팅 송수신/조회</li></ul>                                   |
+| 이서준 | <ul><li>소셜 로그인</li><li>사용자 관리(회원)</li><li>매너온도 평가</li><li>게시물/채팅 신고</li><li>음식 랭킹 관리</li><li>시큐리티 설정</li></ul> |
+| 전정원 | <ul><li>사용자 관리(관리자)</li><li>모임 관리</li><li>신고 관리</li><li>식당 관리</li><li>통계</li><li>사용자/관리자 알림</li></ul>          |
+
+## 4. 기술 스택
+<div align=center> 
+  <img src="https://img.shields.io/badge/springboot-6DB33F?style=for-the-badge&logo=springboot&logoColor=white">
+  <img src="https://img.shields.io/badge/MySQL-4479A1?style=for-the-badge&logo=MySQL&logoColor=white">
+  <img src="https://img.shields.io/badge/spring security-6DB33F?style=for-the-badge&logo=springsecurity&logoColor=white"/>
+  <img src="https://img.shields.io/badge/thymeleaf-005F0F?style=for-the-badge&logo=thymeleaf&logoColor=white"/>
+  <br>
+
+  <img src="https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white"/>
+  <img src="https://img.shields.io/badge/github-181717?style=for-the-badge&logo=github&logoColor=white">
+  <img src="https://img.shields.io/badge/trello-0052CC?style=for-the-badge&logo=trello&logoColor=white">
+  <img src="https://img.shields.io/badge/figma-F24E1E?style=for-the-badge&logo=figma&logoColor=white">
+  <br>
+</div>

--- a/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminContentRankingApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/admin/AdminContentRankingApiController.java
@@ -5,6 +5,8 @@ import com.grepp.matnam.app.model.content.dto.RankingItemDTO;
 import com.grepp.matnam.app.model.content.entity.ContentRanking;
 import com.grepp.matnam.app.model.content.entity.RankingItem;
 import com.grepp.matnam.app.model.content.service.ContentRankingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,11 +17,13 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/admin/content-rankings")
 @RequiredArgsConstructor
+@Tag(name = "Admin Content Ranking API", description = "관리자가 사용자에게 보여줄 랭킹 콘텐츠를 관리하는 API")
 public class AdminContentRankingApiController {
 
     private final ContentRankingService contentRankingService;
 
     @GetMapping
+    @Operation(summary = "모든 랭킹 목록 조회", description = "시스템에 등록된 모든 랭킹 목록을 조회합니다.")
     public ResponseEntity<List<ContentRankingDTO>> getAllRankings() {
         List<ContentRankingDTO> rankings = contentRankingService.getAllRankings()
                 .stream()
@@ -29,6 +33,7 @@ public class AdminContentRankingApiController {
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "특정 랭킹 조회", description = "ID로 특정 랭킹과 그에 속한 항목들을 조회합니다.")
     public ResponseEntity<ContentRankingDTO> getRankingById(@PathVariable Long id) {
         try {
             ContentRanking ranking = contentRankingService.getRankingById(id);
@@ -47,6 +52,7 @@ public class AdminContentRankingApiController {
     }
 
     @PostMapping
+    @Operation(summary = "새로운 랭킹 생성", description = "새로운 랭킹을 생성합니다.")
     public ResponseEntity<ContentRankingDTO> createRanking(@RequestBody ContentRankingDTO dto) {
         try {
             ContentRanking entity = dto.toEntity();
@@ -58,6 +64,7 @@ public class AdminContentRankingApiController {
     }
 
     @PutMapping("/{id}")
+    @Operation(summary = "랭킹 정보 수정", description = "기존 랭킹의 정보를 수정합니다.")
     public ResponseEntity<ContentRankingDTO> updateRanking(
             @PathVariable Long id,
             @RequestBody ContentRankingDTO dto) {
@@ -76,6 +83,7 @@ public class AdminContentRankingApiController {
     }
 
     @DeleteMapping("/{id}")
+    @Operation(summary = "랭킹 삭제", description = "특정 ID의 랭킹을 삭제합니다.")
     public ResponseEntity<Void> deleteRanking(@PathVariable Long id) {
         try {
             contentRankingService.deleteRanking(id);
@@ -86,6 +94,7 @@ public class AdminContentRankingApiController {
     }
 
     @PatchMapping("/{id}/toggle")
+    @Operation(summary = "랭킹 활성화 상태 토글", description = "랭킹의 활성화 상태를 변경합니다. 활성화된 랭킹만 사용자에게 표시됩니다.")
     public ResponseEntity<ContentRankingDTO> toggleRankingStatus(@PathVariable Long id) {
         try {
             ContentRanking updated = contentRankingService.toggleRankingStatus(id);
@@ -96,6 +105,7 @@ public class AdminContentRankingApiController {
     }
 
     @GetMapping("/{rankingId}/items")
+    @Operation(summary = "랭킹 항목 목록 조회", description = "특정 랭킹에 속한 모든 항목을 조회합니다.")
     public ResponseEntity<List<RankingItemDTO>> getRankingItems(@PathVariable Long rankingId) {
         try {
             ContentRanking ranking = contentRankingService.getRankingById(rankingId);
@@ -112,6 +122,7 @@ public class AdminContentRankingApiController {
     }
 
     @PostMapping("/{rankingId}/items")
+    @Operation(summary = "랭킹 항목 추가", description = "특정 랭킹에 새로운 항목을 추가합니다.")
     public ResponseEntity<RankingItemDTO> addRankingItem(
             @PathVariable Long rankingId,
             @RequestBody RankingItemDTO dto) {
@@ -128,6 +139,7 @@ public class AdminContentRankingApiController {
     }
 
     @PutMapping("/{rankingId}/items/{itemId}")
+    @Operation(summary = "랭킹 항목 수정", description = "특정 랭킹의 항목 정보를 수정합니다.")
     public ResponseEntity<RankingItemDTO> updateRankingItem(
             @PathVariable Long rankingId,
             @PathVariable Long itemId,
@@ -148,6 +160,7 @@ public class AdminContentRankingApiController {
     }
 
     @DeleteMapping("/{rankingId}/items/{itemId}")
+    @Operation(summary = "랭킹 항목 삭제", description = "특정 랭킹의 항목을 삭제합니다.")
     public ResponseEntity<Void> deleteRankingItem(
             @PathVariable Long rankingId,
             @PathVariable Long itemId) {
@@ -163,6 +176,7 @@ public class AdminContentRankingApiController {
     }
 
     @PatchMapping("/{rankingId}/items/{itemId}/toggle")
+    @Operation(summary = "랭킹 항목 활성화 상태 토글", description = "랭킹 항목의 활성화 상태를 변경합니다. 활성화된 항목만 사용자에게 표시됩니다.")
     public ResponseEntity<RankingItemDTO> toggleRankingItemStatus(
             @PathVariable Long rankingId,
             @PathVariable Long itemId) {

--- a/src/main/java/com/grepp/matnam/app/controller/api/user/UserApiController.java
+++ b/src/main/java/com/grepp/matnam/app/controller/api/user/UserApiController.java
@@ -1,7 +1,6 @@
 package com.grepp.matnam.app.controller.api.user;
 
 import com.grepp.matnam.app.controller.api.user.payload.*;
-import com.grepp.matnam.infra.response.Messages;
 import com.grepp.matnam.app.model.log.UserActivityLogService;
 import com.grepp.matnam.app.model.user.PreferenceService;
 import com.grepp.matnam.app.model.user.UserService;
@@ -10,6 +9,7 @@ import com.grepp.matnam.infra.auth.AuthenticationUtils;
 import com.grepp.matnam.infra.auth.CookieUtils;
 import com.grepp.matnam.infra.jwt.JwtTokenProvider;
 import com.grepp.matnam.infra.response.ApiResponse;
+import com.grepp.matnam.infra.response.Messages;
 import com.grepp.matnam.infra.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,8 +44,7 @@ public class UserApiController {
 
         int maxAge = 86400;
         CookieUtils.addJwtCookie(response, token, maxAge);
-        CookieUtils.addUserIdCookie(response, user.getUserId(), maxAge);
-        CookieUtils.addUserRoleCookie(response, user.getRole().name(), maxAge);
+        CookieUtils.addUserNicknameCookie(response, user.getNickname(), maxAge);
 
         JwtResponse jwtResponse = JwtResponse.builder()
                 .token(token)
@@ -70,8 +69,7 @@ public class UserApiController {
 
         int maxAge = 86400;
         CookieUtils.addJwtCookie(response, token, maxAge);
-        CookieUtils.addUserIdCookie(response, user.getUserId(), maxAge);
-        CookieUtils.addUserRoleCookie(response, user.getRole().name(), maxAge);
+        CookieUtils.addUserNicknameCookie(response, user.getNickname(), maxAge);
 
         JwtResponse jwtResponse = JwtResponse.builder()
                 .token(token)

--- a/src/main/java/com/grepp/matnam/infra/auth/CookieUtils.java
+++ b/src/main/java/com/grepp/matnam/infra/auth/CookieUtils.java
@@ -36,6 +36,10 @@ public class CookieUtils {
         addCookie(response, "userRole", role, maxAge, "/");
     }
 
+    public static void addUserNicknameCookie(HttpServletResponse response, String nickname, int maxAge) {
+        addCookie(response, "userNickname", nickname, maxAge, "/");
+    }
+
     public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {

--- a/src/main/java/com/grepp/matnam/infra/auth/CookieUtils.java
+++ b/src/main/java/com/grepp/matnam/infra/auth/CookieUtils.java
@@ -6,6 +6,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -37,7 +39,8 @@ public class CookieUtils {
     }
 
     public static void addUserNicknameCookie(HttpServletResponse response, String nickname, int maxAge) {
-        addCookie(response, "userNickname", nickname, maxAge, "/");
+        String encodedNickname = URLEncoder.encode(nickname, StandardCharsets.UTF_8);
+        addCookie(response, "userNickname", encodedNickname, maxAge, "/");
     }
 
     public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
@@ -52,6 +55,11 @@ public class CookieUtils {
 
     public static Optional<String> getJwtToken(HttpServletRequest request) {
         return getCookie(request, "jwtToken")
+                .map(Cookie::getValue);
+    }
+
+    public static Optional<String> getUserNicknameCookie(HttpServletRequest request) {
+        return getCookie(request, "userNickname")
                 .map(Cookie::getValue);
     }
 

--- a/src/main/resources/static/js/admin-common.js
+++ b/src/main/resources/static/js/admin-common.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function () {
   if (auth.isLoggedIn()){
     document.getElementById(
-        'profile-name').textContent = auth.getUserInfo().userId + "님";
+        'profile-name').textContent = auth.getUserInfo().nickname + "님";
   }
 
   // 탭 처리

--- a/src/main/resources/static/js/auth.js
+++ b/src/main/resources/static/js/auth.js
@@ -7,8 +7,7 @@ const auth = {
         if (!this.isLoggedIn()) return null;
 
         return {
-            userId: this.getCookie('userId'),
-            role: this.getCookie('userRole'),
+            nickname: this.getCookie('userNickname'),
             token: this.getCookie('jwtToken')
         };
     },

--- a/src/main/resources/static/js/auth.js
+++ b/src/main/resources/static/js/auth.js
@@ -7,7 +7,7 @@ const auth = {
         if (!this.isLoggedIn()) return null;
 
         return {
-            nickname: this.getCookie('userNickname'),
+            nickname: this.getNickname('userNickname'),
             token: this.getCookie('jwtToken')
         };
     },
@@ -32,6 +32,11 @@ const auth = {
             if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
         }
         return null;
+    },
+
+    getNickname(name) {
+        const encodedNickname = this.getCookie('userNickname');
+        return encodedNickname ? decodeURIComponent(encodedNickname) : null;
     },
 
     eraseCookie(name) {

--- a/src/main/resources/static/js/header.js
+++ b/src/main/resources/static/js/header.js
@@ -35,7 +35,7 @@ function updateHeader() {
         const userInfo = auth.getUserInfo();
         headerAnonymous.style.display = 'none';
         headerLogin.style.display = 'flex';
-        document.getElementById('profile-name').textContent = userInfo.userId + '님';
+        document.getElementById('profile-name').textContent = userInfo.nickname + '님';
     } else if (headerAnonymous && headerLogin && !auth.isLoggedIn()){
         headerAnonymous.style.display = 'flex';
         headerLogin.style.display = 'none';

--- a/src/test/java/com/grepp/matnam/app/controller/web/team/TeamControllerTest.java
+++ b/src/test/java/com/grepp/matnam/app/controller/web/team/TeamControllerTest.java
@@ -1,0 +1,164 @@
+package com.grepp.matnam.app.controller.web.team;
+
+import com.grepp.matnam.app.model.team.ParticipantRepository;
+import com.grepp.matnam.app.model.team.TeamService;
+import com.grepp.matnam.app.model.team.code.ParticipantStatus;
+import com.grepp.matnam.app.model.team.entity.Team;
+import com.grepp.matnam.app.model.user.UserService;
+import com.grepp.matnam.app.model.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.ui.Model;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class TeamControllerTest {
+    @Mock
+    private TeamService teamService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Model model;
+
+    @InjectMocks
+    private TeamController teamController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(teamController).build();
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자도 모임 상세 페이지에 접근할 수 있어야 함")
+    void anonymousUserCanAccessTeamDetail() throws Exception {
+        Authentication anonymousAuth = new AnonymousAuthenticationToken(
+                "anonymous", "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+        );
+
+        when(securityContext.getAuthentication()).thenReturn(anonymousAuth);
+
+        Team mockTeam = new Team();
+        mockTeam.setTeamId(1L);
+        mockTeam.setTeamTitle("테스트 모임");
+        mockTeam.setParticipants(new ArrayList<>());
+
+        when(teamService.getTeamByIdWithParticipants(anyLong())).thenReturn(mockTeam);
+
+        String viewName = teamController.teamDetail(1L, model);
+
+        verify(model).addAttribute(eq("team"), eq(mockTeam));
+        verify(model).addAttribute(eq("participants"), anyList());
+        verify(model).addAttribute(eq("isAnonymous"), eq(true));
+        verify(model).addAttribute(eq("isLeader"), eq(false));
+        verify(model).addAttribute(eq("isParticipant"), eq(false));
+        verify(model).addAttribute(eq("alreadyApplied"), eq(false));
+
+        verify(userService, never()).getUserById(anyString());
+
+        assert viewName.equals("team/teamDetail");
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자는 모임 상세 페이지에서 추가 정보를 볼 수 있어야 함")
+    void authenticatedUserCanAccessTeamDetailWithFullInfo() throws Exception {
+        String userId = "testUser";
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userId, "password",
+                AuthorityUtils.createAuthorityList("ROLE_USER")
+        );
+
+        when(securityContext.getAuthentication()).thenReturn(auth);
+
+        User mockUser = new User();
+        mockUser.setUserId(userId);
+        mockUser.setNickname("테스트 사용자");
+
+        Team mockTeam = new Team();
+        mockTeam.setTeamId(1L);
+        mockTeam.setTeamTitle("테스트 모임");
+        mockUser.setUserId("otherUser");
+        mockTeam.setUser(mockUser);
+        mockTeam.setParticipants(new ArrayList<>());
+
+        when(teamService.getTeamByIdWithParticipants(anyLong())).thenReturn(mockTeam);
+        when(userService.getUserById(userId)).thenReturn(mockUser);
+        when(participantRepository.existsByUser_UserIdAndTeam_TeamIdAndParticipantStatus(
+                eq(userId), anyLong(), eq(ParticipantStatus.APPROVED))).thenReturn(false);
+        when(participantRepository.existsByUser_UserIdAndTeam_TeamIdAndParticipantStatus(
+                eq(userId), anyLong(), eq(ParticipantStatus.PENDING))).thenReturn(false);
+
+        String viewName = teamController.teamDetail(1L, model);
+
+        verify(model).addAttribute(eq("team"), eq(mockTeam));
+        verify(model).addAttribute(eq("participants"), anyList());
+        verify(model).addAttribute(eq("isAnonymous"), eq(false));
+        verify(model).addAttribute(eq("user"), eq(mockUser));
+        verify(model).addAttribute(eq("isLeader"), anyBoolean());
+        verify(model).addAttribute(eq("isParticipant"), anyBoolean());
+        verify(model).addAttribute(eq("alreadyApplied"), anyBoolean());
+
+        verify(userService, times(1)).getUserById(userId);
+
+        assert viewName.equals("team/teamDetail");
+    }
+
+    @Test
+    @DisplayName("익명 사용자 접근 통합 테스트")
+    void anonymousUserCanAccessTeamDetailMvcTest() throws Exception {
+        Authentication anonymousAuth = new AnonymousAuthenticationToken(
+                "anonymous", "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+        );
+
+        when(securityContext.getAuthentication()).thenReturn(anonymousAuth);
+
+        Team mockTeam = new Team();
+        mockTeam.setTeamId(1L);
+        mockTeam.setTeamTitle("테스트 모임");
+        mockTeam.setParticipants(new ArrayList<>());
+
+        when(teamService.getTeamByIdWithParticipants(anyLong())).thenReturn(mockTeam);
+
+        mockMvc.perform(get("/team/detail/1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("team/teamDetail"))
+                .andExpect(model().attributeExists("team"))
+                .andExpect(model().attribute("isAnonymous", true))
+                .andExpect(model().attribute("isLeader", false))
+                .andExpect(model().attribute("isParticipant", false))
+                .andExpect(model().attribute("alreadyApplied", false));
+
+        verify(userService, never()).getUserById(anyString());
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명
기존 쿠키에 저장되던 userId, role을 제거하고 헤더에 닉네임 표시를 위해 ninkname을 추가했습니다. 
추가적으로 TeamController(teamDetail)의 테스트 코드와 AdminContentRankingApiController Swagger의 누락된 설명을 작성했습니다.

## 👩‍💻 요구 사항과 구현 내용
- 쿠키 저장 항목 변경
  - 삭제: 유저 아이디, 유저 권한
  - 추가: 유저 닉네임(인코딩 하여 저장 - 한글 깨짐 문제를 해결하기 위함)
  - 유지: JWT
- auth.js / header.js
  - userId가 헤더에 표시되던 것을 nickname이 표시되도록 함